### PR TITLE
fix(terminal): use isatty for TTY detection instead of char-device check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/vault-client-go v0.4.3
 	github.com/int128/oauth2cli v1.14.0
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
+	github.com/mattn/go-isatty v0.0.22
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
@@ -43,7 +44,6 @@ require (
 	github.com/int128/listener v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
+github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
@@ -434,7 +434,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/mattn/go-isatty"
 )
 
 const (
@@ -29,11 +31,7 @@ func IsRunning(in io.Reader) bool {
 	if !ok {
 		return false
 	}
-	fi, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return (fi.Mode() & os.ModeCharDevice) != 0
+	return isatty.IsTerminal(f.Fd())
 }
 
 func BuildLaunchCommand(command string) (string, error) {

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -7,6 +7,24 @@ import (
 	"testing"
 )
 
+func TestIsRunning_devNull_returnsFalse(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	if IsRunning(f) {
+		t.Errorf("IsRunning(/dev/null) = true, want false (regression: char-device check used to misclassify /dev/null as TTY)")
+	}
+}
+
+func TestIsRunning_nonFile_returnsFalse(t *testing.T) {
+	if IsRunning(&bytes.Buffer{}) {
+		t.Error("IsRunning(*bytes.Buffer) = true, want false")
+	}
+}
+
 func TestWriteLaunchScriptTo_includesShebangSelfDeleteAndKeepAlive(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeLaunchScriptTo(&buf, `echo hi`); err != nil {


### PR DESCRIPTION
## Summary

Real prod bug: every TUI/CLI client (pgcli, k9s, mysql-client, etc.) launched via the `apono://` URI handler chain crashes with "Input is not a terminal (fd=0)" instead of opening in a Terminal.app window.

## Root cause

`pkg/terminal/IsRunning` checked `(fi.Mode() & os.ModeCharDevice) != 0` to decide whether stdin is a real terminal. That bit is set on real TTYs (`/dev/tty`, `/dev/ttysXXX`) **and on `/dev/null`** (and other non-controlling char devices) — they all share the `c` mode bit.

```
$ stat -f "%HT %Sp" /dev/null /dev/tty
Character Device crw-rw-rw-
Character Device crw-rw-rw-
```

When AppleScript's `do shell script` runs the URI handler chain, it connects the spawned shell's stdin to `/dev/null` (or a stripped pty). Our check returned `true` → apono thought it had a real terminal → ran the launcher inline (`pgcli ...`) instead of wrapping it in a Terminal.app window. pgcli's own `isatty(0)` check (via `tcgetattr`) correctly identified the non-TTY, crashed, and AppleScript surfaced the failure as a macOS error dialog.

## Fix

Switch to `mattn/go-isatty.IsTerminal(fd)` which calls `tcgetattr` — succeeds only on real controlling terminals. `/dev/null`, pipes, regular files, stripped ptys all correctly return `false` now.

`go-isatty` was already a transitive dep (via cobra/bubbletea); promoted to direct.

## Test plan

- [x] `go test ./pkg/terminal/...` — new regression tests:
  - `TestIsRunning_devNull_returnsFalse` — opens `/dev/null` and asserts `IsRunning` rejects it (the regression).
  - `TestIsRunning_nonFile_returnsFalse` — non-`*os.File` reader.
- [x] Manual smoke: built local dist, clicked `apono://connect?session=...&client=cli` — Terminal.app window pops with interactive pgcli prompt. Before the fix this produced an error dialog.
- [x] Sanity: direct invocation `apono access use X --client cli` from a real terminal still runs inline (TTY case unchanged).

## Files

- `pkg/terminal/terminal.go` — `IsRunning` now delegates to `isatty.IsTerminal`.
- `pkg/terminal/terminal_test.go` — 2 regression tests.
- `go.mod` / `go.sum` — `github.com/mattn/go-isatty` promoted to direct dep, version v0.0.22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)