### PR TITLE
fix: terminal launch works the first time

### DIFF
--- a/pkg/terminal/scripts/launch.sh
+++ b/pkg/terminal/scripts/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/zsh -l
 rm -- "$0"
 __APONO_COMMAND__
 exec /bin/zsh -l

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -65,7 +65,7 @@ func writeLaunchScript(command string) (string, error) {
 		_ = os.Remove(f.Name())
 		return "", err
 	}
-	if err := os.Chmod(f.Name(), 0o755); err != nil {
+	if err := os.Chmod(f.Name(), 0o500); err != nil {
 		_ = os.Remove(f.Name())
 		return "", err
 	}

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -17,7 +17,7 @@ const (
 
 	binZsh = "/bin/zsh"
 
-	terminalAppLaunchTemplate = `osascript -e 'tell application "%s" to do script "%s %s"' -e 'tell application "%s" to activate'`
+	terminalAppLaunchTemplate = `osascript -e 'do shell script "open -a " & quoted form of "%s" & " " & quoted form of "%s"'`
 	iTermLaunchTemplate       = `osascript -e 'tell application "%s" to create window with default profile command "%s %s"' -e 'tell application "%s" to activate'`
 
 	launchCommandPlaceholder = "__APONO_COMMAND__"
@@ -52,7 +52,7 @@ func writeLaunchScriptTo(w io.Writer, command string) error {
 }
 
 func writeLaunchScript(command string) (string, error) {
-	f, err := os.CreateTemp("", "apono-launch-*.sh")
+	f, err := os.CreateTemp("", "apono-launch-*.command")
 	if err != nil {
 		return "", err
 	}
@@ -62,6 +62,10 @@ func writeLaunchScript(command string) (string, error) {
 		return "", err
 	}
 	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := os.Chmod(f.Name(), 0o755); err != nil {
 		_ = os.Remove(f.Name())
 		return "", err
 	}
@@ -82,7 +86,7 @@ func hasITerm() bool {
 }
 
 func buildTerminalAppLaunchCommand(scriptPath string) string {
-	return fmt.Sprintf(terminalAppLaunchTemplate, terminalAppName, binZsh, scriptPath, terminalAppName)
+	return fmt.Sprintf(terminalAppLaunchTemplate, terminalAppName, scriptPath)
 }
 
 func buildITermLaunchCommand(scriptPath string) string {

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -32,7 +32,7 @@ func TestWriteLaunchScriptTo_includesShebangSelfDeleteAndKeepAlive(t *testing.T)
 	}
 	got := buf.String()
 	for _, want := range []string{
-		"#!/bin/zsh",
+		"#!/bin/zsh -l",
 		`rm -- "$0"`,
 		"echo hi",
 		"exec /bin/zsh -l",
@@ -66,9 +66,25 @@ func TestWriteLaunchScript_returnsExistingPath(t *testing.T) {
 	}
 }
 
+func TestWriteLaunchScript_setsExecutableBit(t *testing.T) {
+	path, err := writeLaunchScript(`true`)
+	if err != nil {
+		t.Fatalf("writeLaunchScript: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("expected executable bit on %q, got mode %v", path, info.Mode())
+	}
+}
+
 func TestBuildTerminalAppLaunchCommand_format(t *testing.T) {
-	got := buildTerminalAppLaunchCommand("/tmp/foo.sh")
-	for _, want := range []string{`osascript`, `Terminal`, `do script`, `/bin/zsh /tmp/foo.sh`, `activate`} {
+	got := buildTerminalAppLaunchCommand("/tmp/foo.command")
+	for _, want := range []string{`osascript`, `Terminal`, `open -a`, `/tmp/foo.command`, `quoted form of`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in script, got %q", want, got)
 		}


### PR DESCRIPTION
## Summary
First time you click an apono:// link to open SSH or k9s, Terminal would appear but the command would silently fail to run. Subsequent clicks worked fine. Now it works on the first click. iTerm users were never affected and remain unaffected.