### PR TITLE
chore: -c shorthand for --client; drop lens from help

### DIFF
--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -116,7 +116,7 @@ func AccessDetails() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&cmdFlags.outputFormat, outputFlagName, "o", "instructions", fmt.Sprintf("output format: %s | %s | %s | %s", services.CliOutputFormat, services.LinkOutputFormat, services.InstructionsOutputFormat, services.JSONOutputFormat))
 	flags.BoolVarP(&cmdFlags.shouldExecuteAccessCommand, runFlagName, "r", false, "execute the cli command")
-	flags.StringVar(&cmdFlags.clientID, clientFlagName, "", "Launch the session in a supported local `client`. Supported on macOS only.\nSupported clients: dbeaver, tableplus, k9s, lens")
+	flags.StringVarP(&cmdFlags.clientID, clientFlagName, "c", "", "Launch the session in a supported local `client`. Supported on macOS only.\nSupported clients: dbeaver, tableplus, k9s")
 
 	cmd.MarkFlagsMutuallyExclusive(runFlagName, clientFlagName)
 

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -17,8 +17,8 @@ const (
 
 	binZsh = "/bin/zsh"
 
-	terminalAppLaunchTemplate = `osascript -e 'tell application "%s" to do script "%s %s"' -e 'tell application "%s" to activate'`
-	iTermLaunchTemplate       = `osascript -e 'tell application "%s" to create window with default profile command "%s %s"' -e 'tell application "%s" to activate'`
+	terminalAppLaunchTemplate = `osascript -e 'tell application "%s" to do script "%s -l %s"' -e 'tell application "%s" to activate'`
+	iTermLaunchTemplate       = `osascript -e 'tell application "%s" to create window with default profile command "%s -l %s"' -e 'tell application "%s" to activate'`
 
 	launchCommandPlaceholder = "__APONO_COMMAND__"
 )

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -68,7 +68,7 @@ func TestWriteLaunchScript_returnsExistingPath(t *testing.T) {
 
 func TestBuildTerminalAppLaunchCommand_format(t *testing.T) {
 	got := buildTerminalAppLaunchCommand("/tmp/foo.sh")
-	for _, want := range []string{`osascript`, `Terminal`, `do script`, `/bin/zsh /tmp/foo.sh`, `activate`} {
+	for _, want := range []string{`osascript`, `Terminal`, `do script`, `/bin/zsh -l /tmp/foo.sh`, `activate`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in script, got %q", want, got)
 		}
@@ -77,7 +77,7 @@ func TestBuildTerminalAppLaunchCommand_format(t *testing.T) {
 
 func TestBuildITermLaunchCommand_format(t *testing.T) {
 	got := buildITermLaunchCommand("/tmp/foo.sh")
-	for _, want := range []string{`osascript`, `iTerm`, `create window with default profile command`, `/bin/zsh /tmp/foo.sh`, `activate`} {
+	for _, want := range []string{`osascript`, `iTerm`, `create window with default profile command`, `/bin/zsh -l /tmp/foo.sh`, `activate`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in script, got %q", want, got)
 		}


### PR DESCRIPTION
## Summary
- `-c` shorthand for --client — quality-of-life. --client is the most-used flag on apono access use and was the only one without a shorthand. **Product Request**
- Drop lens from --client help — Lens isn't shipping as a supported launcher; listing it in the help text promised support we don't have. **Product Request**
- Launcher inherits login PATH - The launcher's temp script was invoked as plain /bin/zsh <script> (non-login, non-interactive), which only sources .zshenv. Brew's PATH setup lives in `.zprofile` per the standard brew shellenv advisory, so anyone with keg-only formulas (mysql-client@8.0, postgresql-client, etc.) hit command not found from the launcher even though the binary worked in their normal terminal. Switching to zsh -l <script> sources .zprofile and resolves brew-installed clients.