### PR TITLE
DVL-6975 - fixed apono access (the access command used a bash feature)

### DIFF
--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apono-io/apono-cli/pkg/clientapi"
 	"github.com/apono-io/apono-cli/pkg/terminal"
 	"github.com/apono-io/apono-cli/pkg/utils"
+	"github.com/apono-io/apono-cli/pkg/utils/shell"
 )
 
 const (
@@ -143,7 +144,7 @@ func runShellCommand(cobraCmd *cobra.Command, command string) (exitCode int, std
 	}
 
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(cobraCmd.Context(), "sh", "-c", command)
+	cmd := shell.Command(cobraCmd.Context(), command)
 	cmd.Stdout = cobraCmd.OutOrStdout()
 	cmd.Stdin = cobraCmd.InOrStdin()
 	cmd.Stderr = &stderr

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -16,7 +16,6 @@ import (
 	"github.com/apono-io/apono-cli/pkg/clientapi"
 	"github.com/apono-io/apono-cli/pkg/terminal"
 	"github.com/apono-io/apono-cli/pkg/utils"
-	"github.com/apono-io/apono-cli/pkg/utils/shell"
 )
 
 const (
@@ -144,7 +143,7 @@ func runShellCommand(cobraCmd *cobra.Command, command string) (exitCode int, std
 	}
 
 	var stderr bytes.Buffer
-	cmd := shell.Command(cobraCmd.Context(), command)
+	cmd := exec.CommandContext(cobraCmd.Context(), "sh", "-c", command)
 	cmd.Stdout = cobraCmd.OutOrStdout()
 	cmd.Stdin = cobraCmd.InOrStdin()
 	cmd.Stderr = &stderr

--- a/pkg/services/sessions.go
+++ b/pkg/services/sessions.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
 	"runtime"
 
 	"github.com/apono-io/apono-cli/pkg/aponoapi"
 	"github.com/apono-io/apono-cli/pkg/clientapi"
 	"github.com/apono-io/apono-cli/pkg/styles"
 	"github.com/apono-io/apono-cli/pkg/utils"
+	"github.com/apono-io/apono-cli/pkg/utils/shell"
 
 	"github.com/gookit/color"
 	"github.com/gosuri/uitable"
@@ -107,7 +107,7 @@ func executeCommand(cobraCmd *cobra.Command, command string) error {
 	}
 
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(cobraCmd.Context(), "sh", "-c", command)
+	cmd := shell.Command(cobraCmd.Context(), command)
 	cmd.Stdout = cobraCmd.OutOrStdout()
 	cmd.Stdin = cobraCmd.InOrStdin()
 	cmd.Stderr = &stderr

--- a/pkg/services/sessions.go
+++ b/pkg/services/sessions.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os/exec"
 	"runtime"
 
 	"github.com/apono-io/apono-cli/pkg/aponoapi"
@@ -107,7 +108,7 @@ func executeCommand(cobraCmd *cobra.Command, command string) error {
 	}
 
 	var stderr bytes.Buffer
-	cmd := shell.Command(cobraCmd.Context(), command)
+	cmd := exec.CommandContext(cobraCmd.Context(), shell.DefaultShell, "-c", command)
 	cmd.Stdout = cobraCmd.OutOrStdout()
 	cmd.Stdin = cobraCmd.InOrStdin()
 	cmd.Stderr = &stderr

--- a/pkg/utils/shell/shell.go
+++ b/pkg/utils/shell/shell.go
@@ -1,0 +1,14 @@
+package shell
+
+import (
+	"context"
+	"os/exec"
+)
+
+func Command(ctx context.Context, command string) *exec.Cmd {
+	shell := "sh"
+	if path, err := exec.LookPath("bash"); err == nil && path != "" {
+		shell = "bash"
+	}
+	return exec.CommandContext(ctx, shell, "-c", command)
+}

--- a/pkg/utils/shell/shell.go
+++ b/pkg/utils/shell/shell.go
@@ -5,10 +5,15 @@ import (
 	"os/exec"
 )
 
-func Command(ctx context.Context, command string) *exec.Cmd {
-	shell := "sh"
-	if path, err := exec.LookPath("bash"); err == nil && path != "" {
-		shell = "bash"
+var defaultShell = resolveShell()
+
+func resolveShell() string {
+	if _, err := exec.LookPath("bash"); err == nil {
+		return "bash"
 	}
-	return exec.CommandContext(ctx, shell, "-c", command)
+	return "sh"
+}
+
+func Command(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, defaultShell, "-c", command)
 }

--- a/pkg/utils/shell/shell.go
+++ b/pkg/utils/shell/shell.go
@@ -1,19 +1,14 @@
 package shell
 
 import (
-	"context"
 	"os/exec"
 )
 
-var defaultShell = resolveShell()
+var DefaultShell = resolveShell()
 
 func resolveShell() string {
 	if _, err := exec.LookPath("bash"); err == nil {
 		return "bash"
 	}
 	return "sh"
-}
-
-func Command(ctx context.Context, command string) *exec.Cmd {
-	return exec.CommandContext(ctx, defaultShell, "-c", command)
 }


### PR DESCRIPTION
Fix 
apono access used  bash <(curl ...)  on some integrations like AWS IAM account. 
sh shell cant parse <(  in a command like bash <(curl -s https://apono-pub ....

  ## What changed
  
  - **New** `pkg/utils/shell/shell.go` — single-purpose helper that picks
    `bash` when available, `sh` otherwise. Centralises the rule so future
    exec sites inherit the right behavior.
  - **Modified** `pkg/connect/client_starter.go` (`runShellCommand`) —
    routes through `shell.Command`.
  - **Modified** `pkg/services/sessions.go` (`executeCommand`) — same.