### PR TITLE
fix: terminal launchers run auth inside the terminal

### DIFF
--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -59,34 +59,34 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 		return fmt.Errorf("client %q is not supported yet.\nSupported clients for this session: %s.\nYou can still copy the connection command and run it manually in your preferred client", clientID, availableIDs(result.Clients))
 	}
 
-	authCommand := utils.FromNullableString(client.AuthCommand)
+	authCommand := strings.TrimSpace(utils.FromNullableString(client.AuthCommand))
 	invocationCommand := client.InvocationCommand
-
-	if strings.TrimSpace(authCommand) != "" {
-		if err := s.executeCommand(cobraCmd, authCommand); err != nil {
-			return err
-		}
-	}
-
-	if strings.Contains(invocationCommand, passwordPlaceholder) {
-		pwd, err := readCachedPassword(sessionID)
-		if err != nil {
-			return fmt.Errorf("resolve credentials: %w", err)
-		}
-		invocationCommand = strings.ReplaceAll(invocationCommand, passwordPlaceholder, encodePassword(pwd, client.PasswordEncoding))
-	}
 
 	switch client.LauncherType {
 	case ClientKindGUI:
-		return s.executeCommand(cobraCmd, invocationCommand)
+		if authCommand != "" {
+			if err := s.executeCommand(cobraCmd, authCommand); err != nil {
+				return err
+			}
+		}
+		inv, err := substitutePasswordPlaceholder(sessionID, invocationCommand, client.PasswordEncoding)
+		if err != nil {
+			return err
+		}
+		return s.executeCommand(cobraCmd, inv)
 
 	case ClientKindTUI, ClientKindTERMINAL, ClientKindCLI:
-		if s.IsRunningInTerminal() {
-			return s.executeCommand(cobraCmd, invocationCommand)
+		if strings.Contains(invocationCommand, passwordPlaceholder) {
+			return fmt.Errorf("%q does not support this authentication type. Contact your admin", clientID)
 		}
-		// Headless context (URI handler chain): no stdin terminal, so wrap the
-		// command in Terminal.app so the user sees a real terminal window.
-		wrapped, err := s.BuildTerminalLaunchCommand(invocationCommand)
+		combined := invocationCommand
+		if authCommand != "" {
+			combined = authCommand + " && " + invocationCommand
+		}
+		if s.IsRunningInTerminal() {
+			return s.executeCommand(cobraCmd, combined)
+		}
+		wrapped, err := s.BuildTerminalLaunchCommand(combined)
 		if err != nil {
 			return fmt.Errorf("build terminal launch command: %w", err)
 		}
@@ -95,6 +95,17 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 	default:
 		return fmt.Errorf("unknown client kind %q for %q", client.LauncherType, clientID)
 	}
+}
+
+func substitutePasswordPlaceholder(sessionID, invocation, encoding string) (string, error) {
+	if !strings.Contains(invocation, passwordPlaceholder) {
+		return invocation, nil
+	}
+	pwd, err := readCachedPassword(sessionID)
+	if err != nil {
+		return "", fmt.Errorf("resolve credentials: %w", err)
+	}
+	return strings.ReplaceAll(invocation, passwordPlaceholder, encodePassword(pwd, encoding)), nil
 }
 
 func (s *ClientStarter) executeCommand(cobraCmd *cobra.Command, command string) error {

--- a/pkg/connect/client_starter_test.go
+++ b/pkg/connect/client_starter_test.go
@@ -103,7 +103,7 @@ func TestStart_GUI_runsShellInline_regardlessOfTTY(t *testing.T) {
 	}
 }
 
-func TestStart_TUI_TTY_runsInline(t *testing.T) {
+func TestStart_TUI_TTY_runsCombinedInline(t *testing.T) {
 	for _, kind := range []string{ClientKindTUI, ClientKindTERMINAL, ClientKindCLI} {
 		t.Run(kind, func(t *testing.T) {
 			clients := []clientapi.LauncherClientModel{
@@ -115,22 +115,45 @@ func TestStart_TUI_TTY_runsInline(t *testing.T) {
 				t.Fatalf("Start returned error: %v", err)
 			}
 
-			if len(*runs) != 2 {
-				t.Fatalf("expected 2 runShell calls (auth + invocation), got %d", len(*runs))
+			if len(*runs) != 1 {
+				t.Fatalf("expected 1 runShell call (combined auth && invocation), got %d", len(*runs))
+			}
+			if (*runs)[0].combined != "setup && k9s" {
+				t.Errorf("expected combined `auth && invocation`, got %q", (*runs)[0].combined)
 			}
 			if len(*wraps) != 0 {
 				t.Errorf("%s with TTY should not wrap, got %d wrap calls", kind, len(*wraps))
-			}
-			for i, call := range *runs {
-				if strings.HasPrefix(call.combined, "WRAPPED(") {
-					t.Errorf("%s with TTY should run inline, got wrapped command at index %d: %q", kind, i, call.combined)
-				}
 			}
 		})
 	}
 }
 
-func TestStart_TUI_NoTTY_wrapsInTerminal(t *testing.T) {
+func TestStart_TUI_placeholderInInvocation_errors(t *testing.T) {
+	for _, kind := range []string{ClientKindTUI, ClientKindTERMINAL, ClientKindCLI} {
+		t.Run(kind, func(t *testing.T) {
+			clients := []clientapi.LauncherClientModel{
+				newClientModel("psql", kind, "setup", "psql password=__APONO_PASSWORD__"),
+			}
+			s, runs, wraps := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
+
+			err := s.Start(newCobraCmd(), nil, "sess-1", "psql")
+			if err == nil {
+				t.Fatal("expected error for __APONO_PASSWORD__ in TUI invocation, got nil")
+			}
+			if !strings.Contains(err.Error(), "does not support this authentication type") {
+				t.Errorf("expected unsupported-auth-type error, got %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), "Contact your admin") {
+				t.Errorf("expected error to direct user to their admin, got %q", err.Error())
+			}
+			if len(*runs) != 0 || len(*wraps) != 0 {
+				t.Errorf("expected no shell or wrap calls when guarded, got runs=%d wraps=%d", len(*runs), len(*wraps))
+			}
+		})
+	}
+}
+
+func TestStart_TUI_NoTTY_wrapsAuthAndInvocationTogether(t *testing.T) {
 	for _, kind := range []string{ClientKindTUI, ClientKindTERMINAL, ClientKindCLI} {
 		t.Run(kind, func(t *testing.T) {
 			clients := []clientapi.LauncherClientModel{
@@ -142,18 +165,42 @@ func TestStart_TUI_NoTTY_wrapsInTerminal(t *testing.T) {
 				t.Fatalf("Start returned error: %v", err)
 			}
 
-			// Auth runs inline (no wrap), invocation gets wrapped.
 			if len(*wraps) != 1 {
 				t.Fatalf("expected 1 buildTerminalLaunchCommand call, got %d", len(*wraps))
 			}
-			if len(*runs) != 2 {
-				t.Fatalf("expected 2 runShell calls (auth inline + wrapped invocation), got %d", len(*runs))
+			if (*wraps)[0] != "setup && k9s" {
+				t.Errorf("expected wrap of combined `auth && invocation`, got %q", (*wraps)[0])
 			}
-			if (*runs)[0].combined != "setup" {
-				t.Errorf("expected first call to be plain auth_command, got %q", (*runs)[0].combined)
+			if len(*runs) != 1 {
+				t.Fatalf("expected 1 runShell call (the wrapped command), got %d", len(*runs))
 			}
-			if !strings.HasPrefix((*runs)[1].combined, "WRAPPED(") {
-				t.Errorf("%s without TTY should wrap invocation, got %q", kind, (*runs)[1].combined)
+			if (*runs)[0].combined != "WRAPPED(setup && k9s)" {
+				t.Errorf("expected wrapped combined command, got %q", (*runs)[0].combined)
+			}
+		})
+	}
+}
+
+func TestStart_TUI_NoTTY_noAuth_wrapsInvocationOnly(t *testing.T) {
+	for _, kind := range []string{ClientKindTUI, ClientKindTERMINAL, ClientKindCLI} {
+		t.Run(kind, func(t *testing.T) {
+			clients := []clientapi.LauncherClientModel{
+				newClientModel("k9s", kind, "", "k9s"),
+			}
+			s, runs, wraps := testClientStarter(false, clients, aponoapi.ConsumedByAponoCli, nil)
+
+			if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s"); err != nil {
+				t.Fatalf("Start returned error: %v", err)
+			}
+
+			if len(*wraps) != 1 {
+				t.Fatalf("expected 1 wrap call, got %d", len(*wraps))
+			}
+			if (*wraps)[0] != "k9s" {
+				t.Errorf("expected wrap of just invocation, got %q", (*wraps)[0])
+			}
+			if len(*runs) != 1 || (*runs)[0].combined != "WRAPPED(k9s)" {
+				t.Errorf("expected single wrapped invocation run, got %+v", *runs)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Click an apono:// link → service needs interactive auth first (AWS SSO browser flow, JumpCloud SSO, etc.) → previously the browser never opened and you saw "client exited with code 254". Auth was running as a child of Apono Connect.app with no terminal and no foreground GUI access, so the browser-open call silently failed.

Now auth and the connection command both run inside one new Terminal window. Auth has a real terminal — the SSO browser opens, you authorize, the connection continues in the same window.

## Technical notes
- For TUI/TERMINAL/CLI launchers, apono-cli combines `auth_command && invocation_command` into one shell command. In headless (apono://) mode, it wraps the combined command in a Terminal launch. In TTY mode, it runs the combined command in your existing terminal. Symmetric.
- Drops Go-side `__APONO_PASSWORD__` substitution for TUI/Terminal/CLI launchers. Placeholder is now structurally GUI-only — URI-style clients need URL-encoded passwords (requires Go-side substitution); non-URI clients use shell expressions for password materialization. A runtime guard errors with "does not support this authentication type. Contact your admin" if a BE template ever uses placeholder for a TUI/Terminal/CLI launcher.
- **Followup not solved here:** interactive auth + GUI launcher combo (e.g. AWS RDS PG + TablePlus, where auth needs a browser AND invocation needs URL-encoded password). Would need apono-cli to wait for the terminal-wrapped auth to finish before running the GUI launcher.