### PR TITLE
fix: handler survives brew upgrade

### DIFF
--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -80,11 +80,7 @@ func Register(out io.Writer) error {
 }
 
 func resolveAponoBinary() (string, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return "", err
-	}
-	return filepath.EvalSymlinks(exe)
+	return os.Executable()
 }
 
 func bundlePath() (string, error) {


### PR DESCRIPTION
## Summary
When you `brew upgrade apono-cli`, the apono:// handler used to break — it kept pointing at the *old* version's binary path, which brew deleted during the upgrade. Clicking an apono:// link after upgrade gave you `no such file or directory: /opt/homebrew/Cellar/apono-cli/<old-version>/bin/apono` and you had to manually re-run `apono access-handler register` to fix it.

Now the handler stores the path you actually invoked apono from (e.g. `/opt/homebrew/bin/apono`, which is brew's symlink) instead of resolving that symlink to the versioned Cellar path at register time. Brew keeps the symlink pointing at the current version, so the handler survives upgrades transparently.

## One-time migration
Anyone upgrading from a pre-fix version to a fix-included version will hit the stale-handler error *one last time* (their existing bundle was baked with the old EvalSymlinks behavior). One manual `apono access-handler register` after the upgrade rebuilds the bundle with the new symlink-preserving behavior, and all subsequent upgrades are transparent.

A separate PR will add a brew post_install hook so this becomes fully automatic for brew users.

## Technical notes
`resolveAponoBinary` in `pkg/urihandler/register.go` no longer calls `filepath.EvalSymlinks` on the result of `os.Executable()`. The symlink path is what we want to bake into the bundle.