### PR TITLE
feat: brew installs and upgrades auto-register the apono:// handler

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,15 @@ brews:
       man1.install Dir["contrib/manpage/apono*.1"]
       bash_completion.install "contrib/completion/bash/apono"
       zsh_completion.install "contrib/completion/zsh/_apono"
+    post_install: |
+      if OS.mac?
+        begin
+          system "#{bin}/apono", "access-handler", "register"
+        rescue StandardError => e
+          opoo "Failed to register apono:// URL handler: #{e.message}"
+          opoo "Run `apono access-handler register` manually."
+        end
+      end
 
 scoop:
   bucket:


### PR DESCRIPTION
## Summary
Today, registering the apono:// URL handler is a manual step the first time you log in (and after some upgrades it needs to be re-run by hand). After this change, **every `brew install apono-cli` and `brew upgrade apono-cli` runs the registration automatically.** Clicking apono:// links from Portal or Slack just works — no extra command needed by the user, even right after an upgrade.

If the auto-registration fails for any reason (unusual macOS state, missing permission, etc.), brew still installs successfully and prints a warning telling the user to run `apono access-handler register` manually.

## Technical notes
- Adds `post_install:` to `.goreleaser.yaml`'s brews block. goreleaser writes this into the generated Homebrew formula as a `def post_install` Ruby method, which brew runs after every install and upgrade.
- macOS-only via `OS.mac?` guard (the apono:// handler is macOS-specific).
- Wrapped in `begin/rescue StandardError` so a register failure doesn't cause `brew install` to exit non-zero. Brew's `opoo` prints a yellow warning with manual-recovery instructions.
- Verified locally by running `goreleaser release --snapshot` and inspecting the generated `dist/apono-cli.rb` — the `def post_install` method renders correctly.

## Follow-up to drop later
The login-time auto-register (`pkg/commands/auth/actions/access_handler_register.go` + the `access_handler_announced` config flag) can be removed once we're confident brew installs cover the user base. Kept for now as a belt-and-suspenders fallback.