### PR TITLE
fix: relocate apono:// handler bundle out of ~/Applications

### DIFF
--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -111,7 +111,7 @@ func unregisterLegacyBundle() {
 	if _, err := os.Stat(legacyPath); err != nil {
 		return
 	}
-	_ = exec.CommandContext(context.Background(), lsregisterPath, "-u", legacyPath).Run()
+	_, _ = unregisterFromLaunchServices(legacyPath)
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -27,8 +27,14 @@ const (
 	urlSchemeName     = "Apono Connect"
 	urlScheme         = "apono"
 
-	applicationsDirName             = "Applications"
-	applicationsDirPerm os.FileMode = 0o700
+	// Bundle lives under ~/Library/Application Support/apono-cli/ rather than
+	// ~/Applications. macOS's App Management TCC restriction blocks writes to
+	// bundles inside Applications folders from any process whose responsible
+	// chain hasn't been granted the permission (brew post_install, launchd-spawned
+	// upgrades, etc.). Library/Application Support is outside that restriction.
+	bundleParentDir     = "Library/Application Support/apono-cli"
+	legacyBundleDir     = "Applications"
+	bundleParentDirPerm os.FileMode = 0o700
 	handlerScriptPerm   os.FileMode = 0o600
 )
 
@@ -71,6 +77,8 @@ func Register(out io.Writer) error {
 		return fmt.Errorf("build app bundle: %w", err)
 	}
 
+	cleanupLegacyBundle()
+
 	if err = registerWithLaunchServices(bundleDir); err != nil {
 		return fmt.Errorf("register with LaunchServices: %w", err)
 	}
@@ -92,11 +100,30 @@ func bundlePath() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
-	apps := filepath.Join(home, applicationsDirName)
-	if err = os.MkdirAll(apps, applicationsDirPerm); err != nil {
-		return "", fmt.Errorf("mkdir %s: %w", apps, err)
+	parent := filepath.Join(home, bundleParentDir)
+	if err = os.MkdirAll(parent, bundleParentDirPerm); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", parent, err)
 	}
-	return filepath.Join(apps, bundleDirName), nil
+	return filepath.Join(parent, bundleDirName), nil
+}
+
+// cleanupLegacyBundle removes any leftover ~/Applications/Apono Connect.app
+// from earlier apono-cli versions. Unregisters it from LaunchServices so it
+// no longer claims apono:// and tries to delete the on-disk bundle. Both
+// operations are best-effort: the delete fails in restricted contexts (App
+// Management TCC), in which case the bundle persists on disk as harmless
+// orphaned junk that the user can drag to Trash from Finder.
+func cleanupLegacyBundle() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	legacyPath := filepath.Join(home, legacyBundleDir, bundleDirName)
+	if _, err := os.Stat(legacyPath); err != nil {
+		return
+	}
+	_ = exec.CommandContext(context.Background(), lsregisterPath, "-u", legacyPath).Run()
+	_ = os.RemoveAll(legacyPath)
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -28,6 +28,7 @@ const (
 	urlScheme         = "apono"
 
 	bundleParentDir                 = "Library/Application Support/apono-cli"
+	legacyBundleDir                 = "Applications"
 	bundleParentDirPerm os.FileMode = 0o700
 	handlerScriptPerm   os.FileMode = 0o600
 )
@@ -71,6 +72,8 @@ func Register(out io.Writer) error {
 		return fmt.Errorf("build app bundle: %w", err)
 	}
 
+	unregisterLegacyBundle()
+
 	if err = registerWithLaunchServices(bundleDir); err != nil {
 		return fmt.Errorf("register with LaunchServices: %w", err)
 	}
@@ -97,6 +100,18 @@ func bundlePath() (string, error) {
 		return "", fmt.Errorf("mkdir %s: %w", parent, err)
 	}
 	return filepath.Join(parent, bundleDirName), nil
+}
+
+func unregisterLegacyBundle() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	legacyPath := filepath.Join(home, legacyBundleDir, bundleDirName)
+	if _, err := os.Stat(legacyPath); err != nil {
+		return
+	}
+	_ = exec.CommandContext(context.Background(), lsregisterPath, "-u", legacyPath).Run()
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -100,15 +100,9 @@ func bundlePath() (string, error) {
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {
-	if _, err := os.Stat(bundleDir); err == nil {
-		// Bundle exists. The apono binary path baked into handler.sh is the only
-		// thing that varies between registers, so update just that and re-sign.
-		// Avoids wiping a codesigned bundle, which fails in restricted contexts
-		// (brew post_install, anywhere lacking App Management TCC permission).
-		if err := writeHandlerScript(bundleDir, aponoBinary); err != nil {
-			return err
-		}
-		return codesignAdHoc(bundleDir)
+	// Wipe any prior bundle for clean state — register is idempotent.
+	if err := os.RemoveAll(bundleDir); err != nil {
+		return fmt.Errorf("clean previous bundle: %w", err)
 	}
 
 	if err := compileAppleScript(bundleDir); err != nil {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -27,11 +27,6 @@ const (
 	urlSchemeName     = "Apono Connect"
 	urlScheme         = "apono"
 
-	// Bundle lives under ~/Library/Application Support/apono-cli/ rather than
-	// ~/Applications. macOS's App Management TCC restriction blocks writes to
-	// bundles inside Applications folders from any process whose responsible
-	// chain hasn't been granted the permission (brew post_install, launchd-spawned
-	// upgrades, etc.). Library/Application Support is outside that restriction.
 	bundleParentDir                 = "Library/Application Support/apono-cli"
 	bundleParentDirPerm os.FileMode = 0o700
 	handlerScriptPerm   os.FileMode = 0o600

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -100,9 +100,15 @@ func bundlePath() (string, error) {
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {
-	// Wipe any prior bundle for clean state — register is idempotent.
-	if err := os.RemoveAll(bundleDir); err != nil {
-		return fmt.Errorf("clean previous bundle: %w", err)
+	if _, err := os.Stat(bundleDir); err == nil {
+		// Bundle exists. The apono binary path baked into handler.sh is the only
+		// thing that varies between registers, so update just that and re-sign.
+		// Avoids wiping a codesigned bundle, which fails in restricted contexts
+		// (brew post_install, anywhere lacking App Management TCC permission).
+		if err := writeHandlerScript(bundleDir, aponoBinary); err != nil {
+			return err
+		}
+		return codesignAdHoc(bundleDir)
 	}
 
 	if err := compileAppleScript(bundleDir); err != nil {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -32,8 +32,7 @@ const (
 	// bundles inside Applications folders from any process whose responsible
 	// chain hasn't been granted the permission (brew post_install, launchd-spawned
 	// upgrades, etc.). Library/Application Support is outside that restriction.
-	bundleParentDir     = "Library/Application Support/apono-cli"
-	legacyBundleDir     = "Applications"
+	bundleParentDir                 = "Library/Application Support/apono-cli"
 	bundleParentDirPerm os.FileMode = 0o700
 	handlerScriptPerm   os.FileMode = 0o600
 )
@@ -77,8 +76,6 @@ func Register(out io.Writer) error {
 		return fmt.Errorf("build app bundle: %w", err)
 	}
 
-	cleanupLegacyBundle()
-
 	if err = registerWithLaunchServices(bundleDir); err != nil {
 		return fmt.Errorf("register with LaunchServices: %w", err)
 	}
@@ -105,25 +102,6 @@ func bundlePath() (string, error) {
 		return "", fmt.Errorf("mkdir %s: %w", parent, err)
 	}
 	return filepath.Join(parent, bundleDirName), nil
-}
-
-// cleanupLegacyBundle removes any leftover ~/Applications/Apono Connect.app
-// from earlier apono-cli versions. Unregisters it from LaunchServices so it
-// no longer claims apono:// and tries to delete the on-disk bundle. Both
-// operations are best-effort: the delete fails in restricted contexts (App
-// Management TCC), in which case the bundle persists on disk as harmless
-// orphaned junk that the user can drag to Trash from Finder.
-func cleanupLegacyBundle() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-	legacyPath := filepath.Join(home, legacyBundleDir, bundleDirName)
-	if _, err := os.Stat(legacyPath); err != nil {
-		return
-	}
-	_ = exec.CommandContext(context.Background(), lsregisterPath, "-u", legacyPath).Run()
-	_ = os.RemoveAll(legacyPath)
 }
 
 func buildAppBundle(bundleDir, aponoBinary string) error {

--- a/pkg/urihandler/unregister.go
+++ b/pkg/urihandler/unregister.go
@@ -19,6 +19,8 @@ func Unregister(out io.Writer) error {
 		return err
 	}
 
+	unregisterLegacyBundle()
+
 	if _, statErr := os.Stat(bundleDir); os.IsNotExist(statErr) {
 		_, err = fmt.Fprintln(out, "Protocol handler is not registered")
 		return err

--- a/pkg/urihandler/unregister.go
+++ b/pkg/urihandler/unregister.go
@@ -19,6 +19,8 @@ func Unregister(out io.Writer) error {
 		return err
 	}
 
+	cleanupLegacyBundle()
+
 	if _, statErr := os.Stat(bundleDir); os.IsNotExist(statErr) {
 		_, err = fmt.Fprintln(out, "Protocol handler is not registered")
 		return err

--- a/pkg/urihandler/unregister.go
+++ b/pkg/urihandler/unregister.go
@@ -19,8 +19,6 @@ func Unregister(out io.Writer) error {
 		return err
 	}
 
-	cleanupLegacyBundle()
-
 	if _, statErr := os.Stat(bundleDir); os.IsNotExist(statErr) {
 		_, err = fmt.Fprintln(out, "Protocol handler is not registered")
 		return err


### PR DESCRIPTION
## Summary
Moves the apono:// URL handler bundle out of `~/Applications` to `~/Library/Application Support/apono-cli`. Lets brew install/upgrade (#99) register the handler reliably — the old location ran into a macOS permission restriction for some users.