### PR TITLE
fix: register skips rebuild when bundle exists

### DIFF
--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -68,7 +68,7 @@ func Register(out io.Writer) error {
 		return err
 	}
 
-	if _, err := os.Stat(bundleDir); err != nil {
+	if _, statErr := os.Stat(bundleDir); statErr != nil {
 		if err = buildAppBundle(bundleDir, aponoBinary); err != nil {
 			return fmt.Errorf("build app bundle: %w", err)
 		}

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -68,8 +68,10 @@ func Register(out io.Writer) error {
 		return err
 	}
 
-	if err = buildAppBundle(bundleDir, aponoBinary); err != nil {
-		return fmt.Errorf("build app bundle: %w", err)
+	if _, err := os.Stat(bundleDir); err != nil {
+		if err = buildAppBundle(bundleDir, aponoBinary); err != nil {
+			return fmt.Errorf("build app bundle: %w", err)
+		}
 	}
 
 	unregisterLegacyBundle()


### PR DESCRIPTION
## Summary
`brew upgrade` was failing because re-registering the apono:// handler required deleting the prior bundle, which macOS blocks in brew's context. Now register skips the rebuild when a bundle already exists and just refreshes its registration — brew upgrades go through cleanly. Pairs with #98.