### PR TITLE
feat: ship pre-built apono:// handler bundle in brew tarball

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,7 +13,7 @@ jobs:
     # macOS runner so the apono:// handler bundle pre-build step (osacompile +
     # codesign) works during goreleaser. PR CI stays on ubuntu — it doesn't
     # produce real release artifacts.
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3.3.0
         with:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -10,7 +10,10 @@ jobs:
     permissions:
       contents: write
       packages: write
-    runs-on: ubuntu-22.04
+    # macOS runner so the apono:// handler bundle pre-build step (osacompile +
+    # codesign) works during goreleaser. PR CI stays on ubuntu — it doesn't
+    # produce real release artifacts.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3.3.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ contrib
 # Local files
 apono
 docs/plans/
+/.build/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,10 @@ before:
   hooks:
     - make manpage completions
     - go mod tidy
+    # Pre-build the apono:// handler bundle for inclusion in the macOS archive.
+    # Brew's post_install can't osacompile a bundle on the user's machine
+    # (sandbox restriction), so we build it once here in CI and ship it.
+    - bash -c 'if [ "$(uname)" = "Darwin" ]; then mkdir -p .build && go run ./cmd/build-handler-bundle ".build/Apono Connect.app"; fi'
 
 builds:
   - id: apono
@@ -47,6 +51,12 @@ archives:
       - LICENSE
       - contrib/completion/**/*
       - contrib/manpage/*
+      # macOS-only: ship the pre-built apono:// handler bundle. Brew's
+      # post_install will `open -a` this to trigger self-install into
+      # ~/Library/Application Support/apono-cli/. Other platforms ignore
+      # the file (it's just present in the tarball).
+      - src: ".build/Apono Connect.app"
+        dst: "Apono Connect.app"
 
 nfpms:
   - vendor: Apono
@@ -84,14 +94,16 @@ brews:
       man1.install Dir["contrib/manpage/apono*.1"]
       bash_completion.install "contrib/completion/bash/apono"
       zsh_completion.install "contrib/completion/zsh/_apono"
+      (pkgshare/"handler").install "Apono Connect.app"
     post_install: |
       if OS.mac?
-        begin
-          system "#{bin}/apono", "access-handler", "register"
-        rescue StandardError => e
-          opoo "Failed to register apono:// URL handler: #{e.message}"
-          opoo "Run `apono access-handler register` manually."
-        end
+        bundle = "#{pkgshare}/handler/Apono Connect.app"
+        # `open -a` launches the bundle in user-context launchd (not brew's
+        # sandbox). The bundle's AppleScript `on run` handler then self-installs
+        # into ~/Library/Application Support/apono-cli/ and registers with
+        # LaunchServices. Brew's own context is sandboxed out of user $HOME, so
+        # this two-step launch is the only path that works without manual user action.
+        system "/usr/bin/open", "-a", bundle
       end
 
 scoop:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,10 @@ before:
     # Pre-build the apono:// handler bundle for inclusion in the macOS archive.
     # Brew's post_install can't osacompile a bundle on the user's machine
     # (sandbox restriction), so we build it once here in CI and ship it.
-    - bash -c 'if [ "$(uname)" = "Darwin" ]; then mkdir -p .build && go run ./cmd/build-handler-bundle ".build/Apono Connect.app"; fi'
+    # On non-macOS hosts (e.g. PR CI on Linux) we create an empty placeholder
+    # so the archive globbing still finds something — the bundle ships in every
+    # archive but only matters on macOS where post_install actually opens it.
+    - bash -c 'mkdir -p ".build/Apono Connect.app"; if [ "$(uname)" = "Darwin" ]; then go run ./cmd/build-handler-bundle ".build/Apono Connect.app"; fi'
 
 builds:
   - id: apono

--- a/cmd/build-handler-bundle/main.go
+++ b/cmd/build-handler-bundle/main.go
@@ -1,0 +1,24 @@
+// Command build-handler-bundle pre-builds the Apono Connect.app handler bundle
+// for inclusion in the Homebrew tarball. Invoked from goreleaser's before
+// hooks during release. The resulting bundle is shipped to users and
+// self-installs into ~/Library/Application Support/apono-cli/ when brew's
+// post_install opens it via `open -a`.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/apono-io/apono-cli/pkg/urihandler"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: build-handler-bundle <output-path>")
+		os.Exit(2)
+	}
+	if err := urihandler.BuildBundleAt(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "build-handler-bundle: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 )
 
 //go:embed scripts/handler.applescript
@@ -50,17 +49,14 @@ var infoPlistEntries = []struct {
 	{"CFBundleURLTypes", "-array", urlTypesValue},
 }
 
-// Register currently builds the bundle on user invocation. Long-term this
-// becomes a package-install hook (Homebrew post-install, deb/rpm postinst,
-// Scoop) - manual for now.
+// Register builds the apono:// handler bundle at the canonical location and
+// registers it with LaunchServices. Used as a manual fallback (e.g. for
+// non-brew installs) and by the login-time auto-register flow. Brew installs
+// don't call this — they ship a pre-built bundle and use `open -a` to launch
+// it (see scripts/handler.applescript's `on run` self-install handler).
 func Register(out io.Writer) error {
 	if runtime.GOOS != darwinOS {
 		return fmt.Errorf("access-handler is only supported on macOS")
-	}
-
-	aponoBinary, err := resolveAponoBinary()
-	if err != nil {
-		return fmt.Errorf("resolve apono binary: %w", err)
 	}
 
 	bundleDir, err := bundlePath()
@@ -68,7 +64,7 @@ func Register(out io.Writer) error {
 		return err
 	}
 
-	if err = buildAppBundle(bundleDir, aponoBinary); err != nil {
+	if err = BuildBundleAt(bundleDir); err != nil {
 		return fmt.Errorf("build app bundle: %w", err)
 	}
 
@@ -82,12 +78,23 @@ func Register(out io.Writer) error {
 	return err
 }
 
-func resolveAponoBinary() (string, error) {
-	exe, err := os.Executable()
-	if err != nil {
-		return "", err
+// BuildBundleAt produces a complete apono:// handler bundle at the given path.
+// Used at release time by goreleaser to pre-build the bundle for the brew
+// tarball, and at runtime by Register for the manual / login-time fallback.
+func BuildBundleAt(bundleDir string) error {
+	if err := os.RemoveAll(bundleDir); err != nil {
+		return fmt.Errorf("clean previous bundle: %w", err)
 	}
-	return filepath.EvalSymlinks(exe)
+	if err := compileAppleScript(bundleDir); err != nil {
+		return err
+	}
+	if err := patchInfoPlist(bundleDir); err != nil {
+		return err
+	}
+	if err := writeHandlerScript(bundleDir); err != nil {
+		return err
+	}
+	return codesignAdHoc(bundleDir)
 }
 
 func bundlePath() (string, error) {
@@ -112,26 +119,6 @@ func unregisterLegacyBundle() {
 		return
 	}
 	_, _ = unregisterFromLaunchServices(legacyPath)
-}
-
-func buildAppBundle(bundleDir, aponoBinary string) error {
-	// Wipe any prior bundle for clean state — register is idempotent.
-	if err := os.RemoveAll(bundleDir); err != nil {
-		return fmt.Errorf("clean previous bundle: %w", err)
-	}
-
-	if err := compileAppleScript(bundleDir); err != nil {
-		return err
-	}
-	if err := patchInfoPlist(bundleDir); err != nil {
-		return err
-	}
-	if err := writeHandlerScript(bundleDir, aponoBinary); err != nil {
-		return err
-	}
-	// codesign breaks after Info.plist edits; re-sign ad-hoc so LaunchServices
-	// is willing to dispatch Apple Events to the bundle.
-	return codesignAdHoc(bundleDir)
 }
 
 func compileAppleScript(bundleDir string) error {
@@ -179,17 +166,11 @@ func writePlistEntry(plist, key, valueType, value string) error {
 	return nil
 }
 
-// handlerScriptBody returns the handler.sh contents with the apono binary path
-// substituted. Pure, side-effect-free — used by writeHandlerScript and tests.
-func handlerScriptBody(aponoBinary string) string {
-	return strings.ReplaceAll(handlerShellTemplate, "__APONO_BINARY__", aponoBinary)
-}
-
-func writeHandlerScript(bundleDir, aponoBinary string) error {
+func writeHandlerScript(bundleDir string) error {
 	target := filepath.Join(bundleDir, "Contents", "Resources", "handler.sh")
 	// AppleScript invokes this via `zsh -l handler.sh ...`, so the file is
 	// read by zsh as a script — no executable bit required.
-	if err := os.WriteFile(target, []byte(handlerScriptBody(aponoBinary)), handlerScriptPerm); err != nil {
+	if err := os.WriteFile(target, []byte(handlerShellTemplate), handlerScriptPerm); err != nil {
 		return fmt.Errorf("write handler.sh: %w", err)
 	}
 	return nil

--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -7,44 +7,20 @@ import (
 	"testing"
 )
 
-func TestHandlerScriptBody_substitutesAponoBinaryPath(t *testing.T) {
-	body := handlerScriptBody("/fake/path/to/apono")
-
-	if strings.Contains(body, "__APONO_BINARY__") {
-		t.Errorf("expected __APONO_BINARY__ placeholder to be replaced, got:\n%s", body)
-	}
-	if !strings.Contains(body, `exec "/fake/path/to/apono" access use`) {
-		t.Errorf("expected handler.sh to invoke the absolute apono path, got:\n%s", body)
-	}
-}
-
-func TestHandlerScriptBody_setsAccountEnvAndRequiredFlags(t *testing.T) {
-	body := handlerScriptBody("/usr/local/bin/apono")
-
+func TestHandlerShellTemplate_invokesPATHResolvedApono(t *testing.T) {
 	wantSubstrings := []string{
+		`exec apono access use`,
 		`export _APONO_ACCOUNT_ID_="$account"`,
 		`--client "$client"`,
 		`exit 64`,
 	}
 	for _, want := range wantSubstrings {
-		if !strings.Contains(body, want) {
-			t.Errorf("expected handler.sh body to contain %q, got:\n%s", want, body)
+		if !strings.Contains(handlerShellTemplate, want) {
+			t.Errorf("expected handler.sh body to contain %q, got:\n%s", want, handlerShellTemplate)
 		}
 	}
-}
-
-func TestHandlerScriptBody_overwritesPreviousPath(t *testing.T) {
-	first := handlerScriptBody("/fake/first")
-	second := handlerScriptBody("/fake/second")
-
-	if !strings.Contains(second, `"/fake/second"`) {
-		t.Errorf("expected second body to contain second path, got:\n%s", second)
-	}
-	if strings.Contains(second, `"/fake/first"`) {
-		t.Errorf("each call should be independent — second body shouldn't carry first path, got:\n%s", second)
-	}
-	if first == second {
-		t.Error("different inputs should produce different bodies")
+	if strings.Contains(handlerShellTemplate, "__APONO_BINARY__") {
+		t.Errorf("handler.sh should not contain __APONO_BINARY__ placeholder (uses PATH-resolved apono now), got:\n%s", handlerShellTemplate)
 	}
 }
 

--- a/pkg/urihandler/scripts/handler.applescript
+++ b/pkg/urihandler/scripts/handler.applescript
@@ -1,3 +1,19 @@
+on run
+	-- Self-install: invoked when brew post_install does `open -a` on the
+	-- bundle shipped under /opt/homebrew/.../share/. Copies the bundle into
+	-- ~/Library/Application Support/apono-cli/ (the canonical location) and
+	-- registers it with LaunchServices.
+	set srcPath to POSIX path of (path to me)
+	set homePath to POSIX path of (path to home folder)
+	set destDir to homePath & "Library/Application Support/apono-cli"
+	set destPath to destDir & "/Apono Connect.app"
+	set lsr to "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+	do shell script "mkdir -p " & quoted form of destDir
+	do shell script "/usr/bin/ditto " & quoted form of srcPath & " " & quoted form of destPath
+	do shell script quoted form of lsr & " -R " & quoted form of destPath
+end run
+
 on open location theURL
 	set scriptPath to POSIX path of ((path to me as text) & "Contents:Resources:handler.sh")
 	try

--- a/pkg/urihandler/scripts/handler.sh
+++ b/pkg/urihandler/scripts/handler.sh
@@ -27,4 +27,4 @@ if [[ "$session$account$client" == *%* ]]; then
   exit 64
 fi
 export _APONO_ACCOUNT_ID_="$account"
-exec "__APONO_BINARY__" access use "$session" --client "$client" >/dev/null
+exec apono access use "$session" --client "$client" >/dev/null


### PR DESCRIPTION
## Summary
`brew install apono-cli` / `brew upgrade apono-cli` now registers the apono:// URL handler automatically, with no warning and no manual step.

Previously, brew's post_install tried to build the handler bundle on the user's machine — that fails because brew's process context is sandbox-restricted out of `$HOME`. Now CI builds the bundle once, ships it inside the tarball, and post_install just opens it. The bundle's AppleScript then self-installs from `/opt/homebrew/.../share/handler/` into `~/Library/Application Support/apono-cli/` and registers with LaunchServices.

## Verified end-to-end
Tested by swapping the local build into brew's Cellar and running `brew postinstall apono-cli`:
- Fresh install (no prior bundle): bundle lands at the canonical path, codesign valid, handler.sh has the new PATH-resolved `apono` invocation, LSDB registered.
- Upgrade overwrite (existing bundle present): bundle gets replaced cleanly, codesign valid after, content hash matches the new source.

## Notes
- `handler.sh` switched from a per-install baked binary path (`__APONO_BINARY__` placeholder) to a PATH-resolved `apono`. This makes the bundle 100% static across installs — same bytes for everyone — so we can ship it pre-built. Brew's `eval "$(brew shellenv)"` in `.zprofile` puts `/opt/homebrew/bin` on PATH, and the AppleScript invokes `handler.sh` via `/bin/zsh -l` (login shell) so PATH resolves correctly.
- `apono access-handler register` (manual command) and the login-time `setupAccessHandler` flow still work as fallbacks for non-brew installs.
- The pre-built bundle ships in every archive (including non-macOS), which is a few KB of overhead on Linux/Windows tarballs. Acceptable cost; not worth per-platform archive customization right now.