### PR TITLE
fix: launcher PATH includes brew keg-only client dirs

### DIFF
--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -24,6 +24,20 @@ func TestHandlerShellTemplate_invokesPATHResolvedApono(t *testing.T) {
 	}
 }
 
+func TestHandlerShellTemplate_appendsBrewKegBinDirs(t *testing.T) {
+	wantSubstrings := []string{
+		`/opt/homebrew/opt/*/bin(N/)`,
+		`/usr/local/opt/*/bin(N/)`,
+		`PATH="$PATH:$opt_dir"`,
+		`export PATH`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(handlerShellTemplate, want) {
+			t.Errorf("expected handler.sh to augment PATH with brew keg dirs (missing %q), got:\n%s", want, handlerShellTemplate)
+		}
+	}
+}
+
 func TestRegister_rejectsNonDarwin(t *testing.T) {
 	if runtime.GOOS == darwinOS {
 		t.Skip("non-darwin guard test")

--- a/pkg/urihandler/scripts/handler.sh
+++ b/pkg/urihandler/scripts/handler.sh
@@ -26,5 +26,13 @@ if [[ "$session$account$client" == *%* ]]; then
   echo "URL-encoded characters not supported in launch params" >&2
   exit 64
 fi
+# zsh -l sources .zprofile but not .zshrc, so keg-only brew formulas
+# (mysql-client, postgresql@*, etc.) miss PATH even when the user's
+# Terminal sees them. Append every brew opt/*/bin to fill the gap.
+for opt_dir in /opt/homebrew/opt/*/bin(N/) /usr/local/opt/*/bin(N/); do
+  PATH="$PATH:$opt_dir"
+done
+export PATH
+
 export _APONO_ACCOUNT_ID_="$account"
 exec apono access use "$session" --client "$client" >/dev/null


### PR DESCRIPTION
## Summary
When a teammate clicks an "open in terminal" link from the Apono portal or Slack on macOS, the launcher sometimes can't find the client binary (mysql, psql, etc.) — even though the exact same client works fine from a regular Terminal. This fixes that gap so launcher invocations behave the same as Terminal invocations for keg-only brew clients.

## Why this happens
Brew clients like `mysql-client` are "keg-only" — brew installs them under `/opt/homebrew/opt/<name>/bin/` and refuses to symlink them into `/opt/homebrew/bin`. Brew's own install instructions tell users to add that opt dir to PATH in `.zshrc`. That works in any Terminal because `.zshrc` is sourced for every interactive shell.

The apono:// launcher starts `zsh -l` (login, non-interactive) which sources `.zprofile` but skips `.zshrc`. The brew base PATH comes through (because `eval "$(brew shellenv)"` is in `.zprofile`), but the keg-only client paths users added to `.zshrc` don't. Launcher PATH ends up shorter than a Terminal PATH, client lookup fails.

## What changes
After `.zprofile` is loaded, handler.sh scans `/opt/homebrew/opt/*/bin` and `/usr/local/opt/*/bin` and appends every existing dir to PATH. Effect: every keg-only brew formula becomes resolvable without the user touching their shell config — covers mysql-client today, postgresql@*, sqlite, openssl@*, etc. without per-tool maintenance.

Appends (not prepends), so the user's existing PATH still wins for any name collision; we only fill gaps. No `.zshrc` is sourced — we deliberately don't want to pull interactive-shell side effects into the launcher.

## Test plan
- [x] Unit test asserts the PATH-augmentation block ships inside handler.sh
- [x] Smoked the block under real `zsh -l` (confirmed `mysql` resolves to the brew keg path after the loop)
- [ ] One human: install with this build, click an "open in terminal" link from the portal for a MySQL session, confirm the session opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)