### PR TITLE
fix: launcher spawns interactive shell so .zshrc loads

### DIFF
--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -17,8 +17,8 @@ const (
 
 	binZsh = "/bin/zsh"
 
-	terminalAppLaunchTemplate = `osascript -e 'tell application "%s" to do script "%s -l %s"' -e 'tell application "%s" to activate'`
-	iTermLaunchTemplate       = `osascript -e 'tell application "%s" to create window with default profile command "%s -l %s"' -e 'tell application "%s" to activate'`
+	terminalAppLaunchTemplate = `osascript -e 'tell application "%s" to do script "%s -il %s"' -e 'tell application "%s" to activate'`
+	iTermLaunchTemplate       = `osascript -e 'tell application "%s" to create window with default profile command "%s -il %s"' -e 'tell application "%s" to activate'`
 
 	launchCommandPlaceholder = "__APONO_COMMAND__"
 )

--- a/pkg/terminal/terminal_test.go
+++ b/pkg/terminal/terminal_test.go
@@ -68,7 +68,7 @@ func TestWriteLaunchScript_returnsExistingPath(t *testing.T) {
 
 func TestBuildTerminalAppLaunchCommand_format(t *testing.T) {
 	got := buildTerminalAppLaunchCommand("/tmp/foo.sh")
-	for _, want := range []string{`osascript`, `Terminal`, `do script`, `/bin/zsh -l /tmp/foo.sh`, `activate`} {
+	for _, want := range []string{`osascript`, `Terminal`, `do script`, `/bin/zsh -il /tmp/foo.sh`, `activate`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in script, got %q", want, got)
 		}
@@ -77,7 +77,7 @@ func TestBuildTerminalAppLaunchCommand_format(t *testing.T) {
 
 func TestBuildITermLaunchCommand_format(t *testing.T) {
 	got := buildITermLaunchCommand("/tmp/foo.sh")
-	for _, want := range []string{`osascript`, `iTerm`, `create window with default profile command`, `/bin/zsh -l /tmp/foo.sh`, `activate`} {
+	for _, want := range []string{`osascript`, `iTerm`, `create window with default profile command`, `/bin/zsh -il /tmp/foo.sh`, `activate`} {
 		if !strings.Contains(got, want) {
 			t.Errorf("expected %q in script, got %q", want, got)
 		}


### PR DESCRIPTION
## Summary
When a coworker clicks an "open in terminal" button from the Apono portal or Slack on macOS, the new window sometimes can't find the client binary (mysql, psql, etc.) — even though the same client works fine when they open it from a regular Terminal. This makes the launcher behave the same as a regular Terminal.

## Why this happens
Brew clients like `mysql-client` are "keg-only" — brew installs them under `/opt/homebrew/opt/<name>/bin/` and refuses to symlink them into `/opt/homebrew/bin`. Brew's install instructions tell users to put the keg path on PATH in `.zshrc`. That works in any Terminal because Terminal opens an interactive shell, which sources `.zshrc`.

The launcher's new window currently spawns its shell with `zsh -l` — login but non-interactive. That sources `.zprofile` (which has `eval brew shellenv`, so `/opt/homebrew/bin` ends up on PATH) but skips `.zshrc`. So everything users added in `.zshrc` — keg-only brew clients, plus mise / asdf / volta / MacPorts / custom dirs — silently goes missing.

## What changes
Two characters in the two `osascript` templates that launch new Terminal.app / iTerm windows: `zsh -l` becomes `zsh -il`. The `-i` adds interactive mode, so `.zshrc` gets sourced in addition to `.zprofile`. Users get the same PATH and shell setup they'd see in any Terminal they open.

## Things to be aware of
- A user's `.zshrc` runs every time the launcher opens a window. If their `.zshrc` is slow (oh-my-zsh + plugins), there's a small startup delay — the same delay they'd see opening a regular Terminal.
- If `.zshrc` prints a banner or runs `clear`, that output appears in the launcher window before the client output. Same look as opening any Terminal.

The launcher's window has a real TTY (it's a fresh Terminal/iTerm window), so `-i` behaves normally — no flakiness from plugins probing stdin without a TTY.

## Test plan
- [x] `pkg/terminal` tests updated and passing
- [ ] One human: install with this build, click an "open in terminal" link for a MySQL session from the portal, confirm the session opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)