### PR TITLE
fix: actually delete legacy ~/Applications handler bundle

### DIFF
--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -116,7 +116,9 @@ func removeLegacyBundle(out io.Writer) {
 	if _, err := os.Stat(legacyPath); err != nil {
 		return
 	}
-	// Unregister before delete: lsregister -u reads the bundle on disk.
+	// Unregister before delete: lsregister -u reads the bundle on disk. If
+	// RemoveAll fails, LSDB is already unregistered; macOS rescan re-adds it
+	// and the next register call retries both steps.
 	_, _ = unregisterFromLaunchServices(legacyPath)
 	if err := os.RemoveAll(legacyPath); err != nil {
 		_, _ = fmt.Fprintf(out, "WARNING: could not remove legacy bundle at %s: %v\n", legacyPath, err)

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -85,7 +85,7 @@ func Register(out io.Writer) error {
 		return fmt.Errorf("build app bundle: %w", err)
 	}
 
-	unregisterLegacyBundle()
+	removeLegacyBundle(out)
 
 	if err = registerWithLaunchServices(bundleDir); err != nil {
 		return fmt.Errorf("register with LaunchServices: %w", err)
@@ -107,7 +107,7 @@ func bundlePath() (string, error) {
 	return filepath.Join(parent, bundleDirName), nil
 }
 
-func unregisterLegacyBundle() {
+func removeLegacyBundle(out io.Writer) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
@@ -117,6 +117,12 @@ func unregisterLegacyBundle() {
 		return
 	}
 	_, _ = unregisterFromLaunchServices(legacyPath)
+	if err := os.RemoveAll(legacyPath); err != nil {
+		_, _ = fmt.Fprintf(out, "WARNING: could not remove legacy bundle at %s: %v\n", legacyPath, err)
+		_, _ = fmt.Fprintln(out, "macOS may keep routing apono:// links to it. Move it to Trash from Finder (allow App Management when prompted), then re-run this command.")
+		return
+	}
+	_, _ = fmt.Fprintf(out, "Removed legacy bundle at %s\n", legacyPath)
 }
 
 func buildAppBundle(bundleDir string) error {

--- a/pkg/urihandler/register.go
+++ b/pkg/urihandler/register.go
@@ -116,6 +116,7 @@ func removeLegacyBundle(out io.Writer) {
 	if _, err := os.Stat(legacyPath); err != nil {
 		return
 	}
+	// Unregister before delete: lsregister -u reads the bundle on disk.
 	_, _ = unregisterFromLaunchServices(legacyPath)
 	if err := os.RemoveAll(legacyPath); err != nil {
 		_, _ = fmt.Fprintf(out, "WARNING: could not remove legacy bundle at %s: %v\n", legacyPath, err)

--- a/pkg/urihandler/unregister.go
+++ b/pkg/urihandler/unregister.go
@@ -18,7 +18,7 @@ func Unregister(out io.Writer) error {
 		return err
 	}
 
-	unregisterLegacyBundle()
+	removeLegacyBundle(out)
 
 	if _, statErr := os.Stat(bundleDir); os.IsNotExist(statErr) {
 		_, err = fmt.Fprintln(out, "Protocol handler is not registered")


### PR DESCRIPTION
## Summary
Older versions of the CLI installed the apono:// handler at `~/Applications/Apono Connect.app`. Register/unregister only called `lsregister -u`, but macOS auto-rescans `~/Applications` and silently re-registers it — so apono:// clicks can still route to a stale bundle that breaks after brew upgrades.

Delete the bundle file too. Warn if macOS App Management blocks it.

## Test plan
- [ ] Legacy bundle present → `apono access-handler register` removes it.
- [ ] First call may trigger an App Management prompt; allow.
- [ ] If denied, warning appears with manual cleanup instructions.