### PR TITLE
fix: show launcher terminal immediately for cloud auth flows

### DIFF
--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -84,12 +84,12 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 		return s.executeCommand(cobraCmd, invocationCommand)
 
 	case ClientKindTUI, ClientKindTERMINAL, ClientKindCLI:
-		if s.IsRunningInTerminal() {
+		if !headlessTerminalLauncher {
 			return s.executeCommand(cobraCmd, invocationCommand)
 		}
 		combined := invocationCommand
 		if authCommand != "" {
-			combined = authCommand + "\n" + invocationCommand
+			combined = authCommand + " && " + invocationCommand
 		}
 		wrapped, err := s.BuildTerminalLaunchCommand(combined)
 		if err != nil {

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -59,10 +59,13 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 		return fmt.Errorf("client %q is not supported yet.\nSupported clients for this session: %s.\nYou can still copy the connection command and run it manually in your preferred client", clientID, availableIDs(result.Clients))
 	}
 
-	authCommand := utils.FromNullableString(client.AuthCommand)
+	authCommand := strings.TrimSpace(utils.FromNullableString(client.AuthCommand))
 	invocationCommand := client.InvocationCommand
 
-	if strings.TrimSpace(authCommand) != "" {
+	headlessTerminalLauncher := !s.IsRunningInTerminal() &&
+		(client.LauncherType == ClientKindTUI || client.LauncherType == ClientKindTERMINAL || client.LauncherType == ClientKindCLI)
+
+	if authCommand != "" && !headlessTerminalLauncher {
 		if err := s.executeCommand(cobraCmd, authCommand); err != nil {
 			return err
 		}
@@ -84,9 +87,11 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 		if s.IsRunningInTerminal() {
 			return s.executeCommand(cobraCmd, invocationCommand)
 		}
-		// Headless context (URI handler chain): no stdin terminal, so wrap the
-		// command in Terminal.app so the user sees a real terminal window.
-		wrapped, err := s.BuildTerminalLaunchCommand(invocationCommand)
+		combined := invocationCommand
+		if authCommand != "" {
+			combined = authCommand + "\n" + invocationCommand
+		}
+		wrapped, err := s.BuildTerminalLaunchCommand(combined)
 		if err != nil {
 			return fmt.Errorf("build terminal launch command: %w", err)
 		}

--- a/pkg/connect/client_starter_test.go
+++ b/pkg/connect/client_starter_test.go
@@ -130,7 +130,7 @@ func TestStart_TUI_TTY_runsInline(t *testing.T) {
 	}
 }
 
-func TestStart_TUI_NoTTY_wrapsInTerminal(t *testing.T) {
+func TestStart_TUI_NoTTY_wrapsAuthAndInvocationTogether(t *testing.T) {
 	for _, kind := range []string{ClientKindTUI, ClientKindTERMINAL, ClientKindCLI} {
 		t.Run(kind, func(t *testing.T) {
 			clients := []clientapi.LauncherClientModel{
@@ -142,20 +142,40 @@ func TestStart_TUI_NoTTY_wrapsInTerminal(t *testing.T) {
 				t.Fatalf("Start returned error: %v", err)
 			}
 
-			// Auth runs inline (no wrap), invocation gets wrapped.
 			if len(*wraps) != 1 {
 				t.Fatalf("expected 1 buildTerminalLaunchCommand call, got %d", len(*wraps))
 			}
-			if len(*runs) != 2 {
-				t.Fatalf("expected 2 runShell calls (auth inline + wrapped invocation), got %d", len(*runs))
+			if (*wraps)[0] != "setup\nk9s" {
+				t.Errorf("expected wrap input to be auth+invocation concatenated, got %q", (*wraps)[0])
 			}
-			if (*runs)[0].combined != "setup" {
-				t.Errorf("expected first call to be plain auth_command, got %q", (*runs)[0].combined)
+			if len(*runs) != 1 {
+				t.Fatalf("expected 1 runShell call (only the wrapped command, auth not run inline), got %d", len(*runs))
 			}
-			if !strings.HasPrefix((*runs)[1].combined, "WRAPPED(") {
-				t.Errorf("%s without TTY should wrap invocation, got %q", kind, (*runs)[1].combined)
+			if !strings.HasPrefix((*runs)[0].combined, "WRAPPED(") {
+				t.Errorf("%s without TTY should run wrapped command, got %q", kind, (*runs)[0].combined)
 			}
 		})
+	}
+}
+
+func TestStart_TUI_NoTTY_emptyAuth_wrapsInvocationOnly(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("k9s", ClientKindTERMINAL, "", "k9s"),
+	}
+	s, runs, wraps := testClientStarter(false, clients, aponoapi.ConsumedByAponoCli, nil)
+
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s"); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	if len(*wraps) != 1 {
+		t.Fatalf("expected 1 buildTerminalLaunchCommand call, got %d", len(*wraps))
+	}
+	if (*wraps)[0] != "k9s" {
+		t.Errorf("expected wrap input to be invocation only when auth is empty, got %q", (*wraps)[0])
+	}
+	if len(*runs) != 1 {
+		t.Fatalf("expected 1 runShell call, got %d", len(*runs))
 	}
 }
 

--- a/pkg/connect/client_starter_test.go
+++ b/pkg/connect/client_starter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -145,8 +146,8 @@ func TestStart_TUI_NoTTY_wrapsAuthAndInvocationTogether(t *testing.T) {
 			if len(*wraps) != 1 {
 				t.Fatalf("expected 1 buildTerminalLaunchCommand call, got %d", len(*wraps))
 			}
-			if (*wraps)[0] != "setup\nk9s" {
-				t.Errorf("expected wrap input to be auth+invocation concatenated, got %q", (*wraps)[0])
+			if (*wraps)[0] != "setup && k9s" {
+				t.Errorf("expected wrap input to be auth && invocation, got %q", (*wraps)[0])
 			}
 			if len(*runs) != 1 {
 				t.Fatalf("expected 1 runShell call (only the wrapped command, auth not run inline), got %d", len(*runs))
@@ -155,6 +156,30 @@ func TestStart_TUI_NoTTY_wrapsAuthAndInvocationTogether(t *testing.T) {
 				t.Errorf("%s without TTY should run wrapped command, got %q", kind, (*runs)[0].combined)
 			}
 		})
+	}
+}
+
+func TestStart_TUI_NoTTY_wrapBuilderFails_returnsWrappedError(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("k9s", ClientKindTERMINAL, "setup", "k9s"),
+	}
+	s, runs, _ := testClientStarter(false, clients, aponoapi.ConsumedByAponoCli, nil)
+	s.BuildTerminalLaunchCommand = func(string) (string, error) {
+		return "", errors.New("osascript path missing")
+	}
+
+	err := s.Start(newCobraCmd(), nil, "sess-1", "k9s")
+	if err == nil {
+		t.Fatal("expected error when BuildTerminalLaunchCommand fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "build terminal launch command") {
+		t.Errorf("expected wrapped error mentioning the failed step, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "osascript path missing") {
+		t.Errorf("expected wrapped error to include the underlying cause, got %q", err.Error())
+	}
+	if len(*runs) != 0 {
+		t.Errorf("expected no runShell calls when wrap builder fails, got %d", len(*runs))
 	}
 }
 


### PR DESCRIPTION
## Summary
When you click an "open in terminal" launcher for a cloud Kubernetes session (EKS, AKS, GKE) on macOS, you used to stare at nothing for 2–4 seconds (or more) before a terminal window finally appeared. The CLI was busy running SSO auth (`aws sso login`, `gcloud auth login`, `az login`) inside its own process, with no visible feedback. Looked like a frozen launcher.

This change moves the auth step into the terminal window that opens. The window appears almost immediately, then the auth output streams visibly. Same total wall-clock time, much better perceived responsiveness.