### PR TITLE
fix: actionable message when the CLI session has expired

### DIFF
--- a/pkg/aponoapi/refreshable_token_source.go
+++ b/pkg/aponoapi/refreshable_token_source.go
@@ -1,11 +1,24 @@
 package aponoapi
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"sync"
 
 	"golang.org/x/oauth2"
 )
+
+// ErrSessionExpired replaces the raw OAuth `invalid_grant` error with guidance
+// the user can act on.
+var ErrSessionExpired = errors.New("session expired, please run 'apono logout' and then 'apono login' to continue")
+
+// IsInvalidGrant reports whether err is an OAuth refresh failure — a dead or
+// revoked refresh token, which happens after inactivity or a version upgrade.
+func IsInvalidGrant(err error) bool {
+	var re *oauth2.RetrieveError
+	return errors.As(err, &re) && bytes.Contains(re.Body, []byte("invalid_grant"))
+}
 
 // TokenUpdateFunc is a function that accepts an oauth2 Token upon refresh, and
 // returns an error if it should not be used.

--- a/pkg/aponoapi/refreshable_token_source_test.go
+++ b/pkg/aponoapi/refreshable_token_source_test.go
@@ -1,0 +1,54 @@
+package aponoapi
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestIsInvalidGrant(t *testing.T) {
+	invalidGrant := &oauth2.RetrieveError{Body: []byte(`{"error":"invalid_grant"}`)}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+		{
+			name: "retrieve error without invalid_grant",
+			err:  &oauth2.RetrieveError{Body: []byte(`{"error":"invalid_client"}`)},
+			want: false,
+		},
+		{
+			name: "bare invalid_grant",
+			err:  invalidGrant,
+			want: true,
+		},
+		{
+			name: "invalid_grant wrapped by net/http and fmt",
+			err:  fmt.Errorf("get session: %w", &url.Error{Op: "Get", URL: "https://api.apono.io", Err: invalidGrant}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInvalidGrant(tt.err); got != tt.want {
+				t.Errorf("IsInvalidGrant() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/commands/apono/runner.go
+++ b/pkg/commands/apono/runner.go
@@ -60,7 +60,13 @@ type Runner struct {
 
 func (r *Runner) Run(ctx context.Context, args []string) error {
 	r.rootCmd.SetArgs(args)
-	return r.rootCmd.ExecuteContext(ctx)
+	if err := r.rootCmd.ExecuteContext(ctx); err != nil {
+		if aponoapi.IsInvalidGrant(err) {
+			return aponoapi.ErrSessionExpired
+		}
+		return err
+	}
+	return nil
 }
 
 func (r *Runner) init() error {


### PR DESCRIPTION
## Summary

When you haven't used the CLI for a while, or right after upgrading it, your saved login can quietly go stale. Today when that happens the CLI prints a raw, cryptic error and leaves you guessing:

```
Error: ... oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant"}
```

This change spots that specific "your login is no longer valid" case and replaces it with a clear next step:

```
Error: session expired, please run 'apono logout' and then 'apono login' to continue
```

Nothing else about how the CLI behaves changes — only the message shown in this one situation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)