### PR TITLE
feat: emit analytics event when launching a client

### DIFF
--- a/pkg/analytics/fields.go
+++ b/pkg/analytics/fields.go
@@ -12,3 +12,18 @@ const (
 	exitCodeField        = "exit_code"
 	flagFieldPrefix      = "flag_"
 )
+
+const (
+	eventLaunchClientRun = "CLI: Command Launch Client Run"
+
+	guiClientField       = "guiClient"
+	sessionIDField       = "session_id"
+	integrationTypeField = "integrationType"
+	originField          = "origin"
+)
+
+const (
+	OriginInteractive = "interactive mode"
+	OriginBrowser     = "browser"
+	OriginFlagRun     = "flag run"
+)

--- a/pkg/analytics/service.go
+++ b/pkg/analytics/service.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -74,6 +75,26 @@ func SendCommandAnalyticsEvent(cmd *cobra.Command, args []string) {
 	}
 
 	_, _ = client.ClientAPI.AnalyticsAPI.SendAnalyticsEvent(cmd.Context()).CreateAnalyticEventClientModel(req).Execute()
+}
+
+func SendLaunchClientEvent(ctx context.Context, clientID, sessionID, integrationType, origin string) {
+	client, err := aponoapi.GetClient(ctx)
+	if err != nil {
+		return
+	}
+
+	req := clientapi.CreateAnalyticEventClientModel{
+		EventName:  eventLaunchClientRun,
+		ClientType: "CLI",
+		Properties: map[string]interface{}{
+			guiClientField:       clientID,
+			sessionIDField:       sessionID,
+			integrationTypeField: integrationType,
+			originField:          origin,
+		},
+	}
+
+	_, _ = client.ClientAPI.AnalyticsAPI.SendAnalyticsEvent(ctx).CreateAnalyticEventClientModel(req).Execute()
 }
 
 func GenerateCommandID() string {

--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -71,7 +71,8 @@ func AccessDetails() *cobra.Command {
 			}
 
 			if cmd.Flags().Changed(clientFlagName) {
-				if err := connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID); err != nil {
+				err = connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID)
+				if err != nil {
 					return err
 				}
 				// _APONO_ACCOUNT_ID_ is set only by the apono:// handler script as a profile-routing signal;

--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/apono-io/apono-cli/pkg/analytics"
 	"github.com/apono-io/apono-cli/pkg/aponoapi"
 	"github.com/apono-io/apono-cli/pkg/config"
 	"github.com/apono-io/apono-cli/pkg/connect"
@@ -70,7 +71,17 @@ func AccessDetails() *cobra.Command {
 			}
 
 			if cmd.Flags().Changed(clientFlagName) {
-				return connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID)
+				if err := connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID); err != nil {
+					return err
+				}
+				// _APONO_ACCOUNT_ID_ is set only by the apono:// handler script as a profile-routing signal;
+				// piggyback on its presence to distinguish a browser-launched run from a terminal-typed --client.
+				origin := analytics.OriginFlagRun
+				if os.Getenv(accountIDEnvVar) != "" {
+					origin = analytics.OriginBrowser
+				}
+				analytics.SendLaunchClientEvent(cmd.Context(), cmdFlags.clientID, session.Id, session.Integration.Type, origin)
+				return nil
 			}
 
 			if len(session.ConnectionMethods) == 0 {

--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -75,10 +75,9 @@ func AccessDetails() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				// _APONO_ACCOUNT_ID_ is set only by the apono:// handler script as a profile-routing signal;
-				// piggyback on its presence to distinguish a browser-launched run from a terminal-typed --client.
+				launchedFromBrowser := os.Getenv(accountIDEnvVar) != ""
 				origin := analytics.OriginFlagRun
-				if os.Getenv(accountIDEnvVar) != "" {
+				if launchedFromBrowser {
 					origin = analytics.OriginBrowser
 				}
 				analytics.SendLaunchClientEvent(cmd.Context(), cmdFlags.clientID, session.Id, session.Integration.Type, origin)

--- a/pkg/interactive/flows/use_session.go
+++ b/pkg/interactive/flows/use_session.go
@@ -80,7 +80,8 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		if err := PrintErrorConnectingSuggestion(cmd, session.Id); err != nil {
 			return err
 		}
-		if err := connect.NewClientStarter().Start(cmd, client, session.Id, selectedID); err != nil {
+		err = connect.NewClientStarter().Start(cmd, client, session.Id, selectedID)
+		if err != nil {
 			return err
 		}
 		analytics.SendLaunchClientEvent(cmd.Context(), selectedID, session.Id, session.Integration.Type, analytics.OriginInteractive)

--- a/pkg/interactive/flows/use_session.go
+++ b/pkg/interactive/flows/use_session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/apono-io/apono-cli/pkg/analytics"
 	"github.com/apono-io/apono-cli/pkg/aponoapi"
 	"github.com/apono-io/apono-cli/pkg/clientapi"
 	"github.com/apono-io/apono-cli/pkg/connect"
@@ -79,7 +80,11 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		if err := PrintErrorConnectingSuggestion(cmd, session.Id); err != nil {
 			return err
 		}
-		return connect.NewClientStarter().Start(cmd, client, session.Id, selectedID)
+		if err := connect.NewClientStarter().Start(cmd, client, session.Id, selectedID); err != nil {
+			return err
+		}
+		analytics.SendLaunchClientEvent(cmd.Context(), selectedID, session.Id, session.Integration.Type, analytics.OriginInteractive)
+		return nil
 
 	default:
 		return fmt.Errorf("unknown access method %s", accessMethod)

--- a/pkg/interactive/flows/use_session.go
+++ b/pkg/interactive/flows/use_session.go
@@ -77,7 +77,8 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		if err != nil {
 			return err
 		}
-		if err := PrintErrorConnectingSuggestion(cmd, session.Id); err != nil {
+		err = PrintErrorConnectingSuggestion(cmd, session.Id)
+		if err != nil {
 			return err
 		}
 		err = connect.NewClientStarter().Start(cmd, client, session.Id, selectedID)


### PR DESCRIPTION
## Summary
Emit a new analytics event whenever a session is launched in a local client — from the `--client` flag or from the interactive "Connect with app" picker.

The event tags whether the launch came from a browser link, the flag, or the interactive flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)