### PR TITLE
fix: rename launch-client analytics event to satisfy backend validator

### DIFF
--- a/pkg/analytics/fields.go
+++ b/pkg/analytics/fields.go
@@ -14,7 +14,7 @@ const (
 )
 
 const (
-	eventLaunchClientRun = "CLI: Command Launch Client Run"
+	eventLaunchClientRun = "Command Launch Client Run"
 
 	guiClientField       = "guiClient"
 	sessionIDField       = "session_id"


### PR DESCRIPTION
## Summary
The event name shipped in #114 (`CLI: Command Launch Client Run`) was rejected by the backend validator — it only accepts alphanumeric characters, spaces, underscores and dashes. As a result no launch-client events were actually being recorded.

Renamed to `Command Launch Client Run`. The `CLI` qualifier was redundant: every event from this binary already carries `ClientType: "CLI"`, matching the existing convention for other CLI events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)