### PR TITLE
Rr3khan/support personal token env auth

### DIFF
--- a/pkg/aponoapi/client_factory.go
+++ b/pkg/aponoapi/client_factory.go
@@ -37,7 +37,7 @@ type Session struct {
 }
 
 func CreateClient(ctx context.Context, profileName string) (*AponoClient, error) {
-	sessionCfg, err := config.GetProfileByName(config.ProfileName(profileName))
+	sessionCfg, err := getSessionConfig(profileName)
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +85,20 @@ func CreateClient(ctx context.Context, profileName string) (*AponoClient, error)
 			UserID:    sessionCfg.UserID,
 		},
 	}, nil
+}
+
+// getSessionConfig resolves the session to use for this invocation. An
+// explicit --profile flag always wins; otherwise a token in the environment
+// takes precedence over the persisted config, so that an environment-provided
+// credential is honored even when a stale profile exists on disk.
+func getSessionConfig(profileName string) (*config.SessionConfig, error) {
+	if profileName == "" {
+		if envCfg := config.GetSessionConfigFromEnv(); envCfg != nil {
+			return envCfg, nil
+		}
+	}
+
+	return config.GetProfileByName(config.ProfileName(profileName))
 }
 
 func CreateClientAPI(endpointURL *url.URL, httpClient *http.Client) *clientapi.APIClient {

--- a/pkg/aponoapi/client_factory_test.go
+++ b/pkg/aponoapi/client_factory_test.go
@@ -1,0 +1,35 @@
+package aponoapi
+
+import (
+	"testing"
+
+	"github.com/apono-io/apono-cli/pkg/config"
+)
+
+func TestGetSessionConfig(t *testing.T) {
+	t.Run("uses the env token when no profile is specified", func(t *testing.T) {
+		t.Setenv(config.PersonalTokenEnvVar, "test-personal-token")
+
+		sessionCfg, err := getSessionConfig("")
+		if err != nil {
+			t.Fatalf("getSessionConfig() error = %v, want nil", err)
+		}
+		if sessionCfg.PersonalToken != "test-personal-token" {
+			t.Errorf("PersonalToken = %q, want %q", sessionCfg.PersonalToken, "test-personal-token")
+		}
+		if sessionCfg.ApiURL != config.APIDefaultURL {
+			t.Errorf("ApiURL = %q, want %q", sessionCfg.ApiURL, config.APIDefaultURL)
+		}
+	})
+
+	t.Run("an explicit profile takes precedence over the env token", func(t *testing.T) {
+		t.Setenv(config.PersonalTokenEnvVar, "test-personal-token")
+
+		// The profile lookup must be attempted (and fail for this nonexistent
+		// profile) instead of falling back to the environment token.
+		sessionCfg, err := getSessionConfig("nonexistent-profile-for-test")
+		if err == nil {
+			t.Fatalf("getSessionConfig() = %+v, want error for nonexistent profile", sessionCfg)
+		}
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -12,6 +13,9 @@ const (
 	APIDefaultURL    = "https://api.apono.io"
 	AppDefaultURL    = "https://app.apono.io"
 	PortalDefaultURL = "https://portal.apono.io"
+
+	PersonalTokenEnvVar = "APONO_PERSONAL_TOKEN"
+	APIURLEnvVar        = "APONO_API_URL"
 )
 
 var (
@@ -102,6 +106,31 @@ func GetProfileByName(profileName ProfileName) (*SessionConfig, error) {
 	}
 
 	return &sessionCfg, nil
+}
+
+// GetSessionConfigFromEnv returns a session authenticated by the personal
+// token in the APONO_PERSONAL_TOKEN environment variable, or nil if the
+// variable is not set. The session is not persisted, so secret managers can
+// authenticate the CLI without a prior `apono login` and without the token
+// ever being written to disk. APONO_API_URL overrides the API endpoint for
+// non-production tenants.
+func GetSessionConfigFromEnv() *SessionConfig {
+	personalToken := os.Getenv(PersonalTokenEnvVar)
+	if personalToken == "" {
+		return nil
+	}
+
+	apiURL := os.Getenv(APIURLEnvVar)
+	if apiURL == "" {
+		apiURL = APIDefaultURL
+	}
+
+	return &SessionConfig{
+		ApiURL:        apiURL,
+		AppURL:        AppDefaultURL,
+		PortalURL:     PortalDefaultURL,
+		PersonalToken: personalToken,
+	}
 }
 
 func IsAccessHandlerAnnounced() bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestGetSessionConfigFromEnv(t *testing.T) {
+	t.Run("returns nil when the token env var is not set", func(t *testing.T) {
+		t.Setenv(PersonalTokenEnvVar, "")
+
+		if sessionCfg := GetSessionConfigFromEnv(); sessionCfg != nil {
+			t.Errorf("GetSessionConfigFromEnv() = %+v, want nil", sessionCfg)
+		}
+	})
+
+	t.Run("returns a personal token session with default URLs", func(t *testing.T) {
+		t.Setenv(PersonalTokenEnvVar, "test-personal-token")
+		t.Setenv(APIURLEnvVar, "")
+
+		sessionCfg := GetSessionConfigFromEnv()
+		if sessionCfg == nil {
+			t.Fatal("GetSessionConfigFromEnv() = nil, want session config")
+		}
+		if sessionCfg.PersonalToken != "test-personal-token" {
+			t.Errorf("PersonalToken = %q, want %q", sessionCfg.PersonalToken, "test-personal-token")
+		}
+		if sessionCfg.ApiURL != APIDefaultURL {
+			t.Errorf("ApiURL = %q, want %q", sessionCfg.ApiURL, APIDefaultURL)
+		}
+		if sessionCfg.AppURL != AppDefaultURL {
+			t.Errorf("AppURL = %q, want %q", sessionCfg.AppURL, AppDefaultURL)
+		}
+		if sessionCfg.PortalURL != PortalDefaultURL {
+			t.Errorf("PortalURL = %q, want %q", sessionCfg.PortalURL, PortalDefaultURL)
+		}
+	})
+
+	t.Run("honors the API URL override env var", func(t *testing.T) {
+		t.Setenv(PersonalTokenEnvVar, "test-personal-token")
+		t.Setenv(APIURLEnvVar, "https://api.example.apono.dev")
+
+		sessionCfg := GetSessionConfigFromEnv()
+		if sessionCfg == nil {
+			t.Fatal("GetSessionConfigFromEnv() = nil, want session config")
+		}
+		if sessionCfg.ApiURL != "https://api.example.apono.dev" {
+			t.Errorf("ApiURL = %q, want %q", sessionCfg.ApiURL, "https://api.example.apono.dev")
+		}
+	})
+}


### PR DESCRIPTION
## Motivation

This enables secret managers to authenticate the Apono CLI per-invocation, without a prior `apono login` and without the token ever being written to disk.

The concrete consumer is 1Password Shell Plugins: 1Password/shell-plugins#625 adds an Apono plugin that stores the personal API token in 1Password. Today the CLI's only token entry point is `apono login --personal-token`, which persists the token in plaintext in `config.json`. With this change, a credential manager (or CI job) can inject `APONO_PERSONAL_TOKEN` into the environment of each command instead, and the token never touches disk — which also lets the shell plugin cover every `apono` command with biometric unlock, the same UX as the AWS/GitHub/etc. plugins.

## What this does

- `pkg/config`: adds `GetSessionConfigFromEnv()`, which builds an unpersisted `SessionConfig` from `APONO_PERSONAL_TOKEN`. `APONO_API_URL` optionally overrides the API endpoint for non-production tenants (defaults to `https://api.apono.io`).
- `pkg/aponoapi`: `CreateClient` resolves its session with explicit precedence:
  1. an explicit `--profile` flag (unchanged behavior),
  2. a token from the environment,
  3. the persisted config's active profile (unchanged behavior).

The env-var session reuses the existing `HTTPClientWithPersonalToken` bearer transport; nothing downstream changes. `Session.AccountID`/`UserID` are empty in this mode — they're only populated at login time today and nothing outside the login flow reads them (account context at runtime comes from the `GetUserSession` API, which works with a bearer token).

## What doesn't change

- No behavior change when `APONO_PERSONAL_TOKEN` is unset.
- An explicit `--profile` flag still always wins, so profile-pinned invocations (e.g. the access-details URI handler) are unaffected.
- `apono login` / `logout` / `profiles` are untouched.

## Testing

- Unit tests for the new env resolution and the precedence rules (stdlib style, `t.Setenv`).
- Full `go test -race ./...` passes.
- Manual verification with a built binary and an isolated `$HOME`:
  - no env var → `Error: no profiles configured, run 'apono login' to create a profile` (unchanged)
  - `APONO_PERSONAL_TOKEN` set → the profile requirement is bypassed and the CLI makes an authenticated API call (verified end-to-end against `api.apono.io`)

## Open questions for maintainers

- Naming: happy to rename the env vars if you have a house convention.
- Docs: if this lands, https://docs.apono.io personal-token and CLI pages should mention the env var — glad to draft that too.