### PR TITLE
Add diagnostics for failed session launches

### DIFF
--- a/pkg/commands/access/actions/handler_log.go
+++ b/pkg/commands/access/actions/handler_log.go
@@ -1,0 +1,30 @@
+package actions
+
+import (
+	"context"
+
+	"github.com/apono-io/apono-cli/pkg/aponoapi"
+	"github.com/apono-io/apono-cli/pkg/logshipping"
+	"github.com/apono-io/apono-cli/pkg/urihandler"
+)
+
+// shipHandlerLog drains the apono:// handler's trace file and forwards each line
+// to the backend under the handler caller. Best-effort: it does nothing without
+// an authenticated client (draining would empty the file with nowhere to ship),
+// and swallows any file error.
+func shipHandlerLog(ctx context.Context) {
+	if client, _ := aponoapi.GetClient(ctx); client == nil {
+		return
+	}
+	path, err := urihandler.HandlerLogPath()
+	if err != nil {
+		return
+	}
+	lines, err := urihandler.DrainLog(path)
+	if err != nil {
+		return
+	}
+	for _, line := range lines {
+		logshipping.Report(ctx, logshipping.CallerHandler, line.Level, line.Message, nil)
+	}
+}

--- a/pkg/commands/access/actions/handler_log_test.go
+++ b/pkg/commands/access/actions/handler_log_test.go
@@ -1,0 +1,34 @@
+package actions
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Without an authenticated client in context, shipHandlerLog must NOT drain the
+// file — draining empties it, and shipping would be a no-op, so the lines would
+// be lost. This guards the "never empty what we can't ship" invariant.
+func TestShipHandlerLog_noClient_doesNotDrainFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logDir := filepath.Join(home, "Library", "Application Support", "apono-cli")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	logPath := filepath.Join(logDir, "handler.log")
+	if err := os.WriteFile(logPath, []byte("INFO\thello\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	shipHandlerLog(context.Background()) // no client in context
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("file was drained without a client — handler logs were lost")
+	}
+}

--- a/pkg/commands/access/actions/handler_log_test.go
+++ b/pkg/commands/access/actions/handler_log_test.go
@@ -24,7 +24,7 @@ func TestShipHandlerLog_noClient_doesNotDrainFile(t *testing.T) {
 
 	shipHandlerLog(context.Background()) // no client in context
 
-	data, err := os.ReadFile(logPath)
+	data, err := os.ReadFile(filepath.Clean(logPath))
 	if err != nil {
 		t.Fatalf("read back: %v", err)
 	}

--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -65,6 +65,8 @@ func AccessDetails() *cobra.Command {
 				return err
 			}
 
+			shipHandlerLog(cmd.Context())
+
 			session, _, err := client.ClientAPI.AccessSessionsAPI.GetAccessSession(cmd.Context(), args[0]).Execute()
 			if err != nil {
 				return fmt.Errorf("access session with id %s not found", args[0])

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -32,6 +32,7 @@ const (
 	fieldClientID        = "client_id"
 	fieldLauncherType    = "launcher_type"
 	fieldIsTerminal      = "is_terminal"
+	fieldError           = "error"
 )
 
 type ClientStarter struct {
@@ -39,6 +40,7 @@ type ClientStarter struct {
 	RunShellCommand            func(*cobra.Command, string) (int, string, error)
 	BuildTerminalLaunchCommand func(string) (string, error)
 	IsRunningInTerminal        func() bool
+	Report                     func(ctx context.Context, level, message string, fields map[string]string)
 }
 
 func NewClientStarter() *ClientStarter {
@@ -47,6 +49,9 @@ func NewClientStarter() *ClientStarter {
 		RunShellCommand:            runShellCommand,
 		BuildTerminalLaunchCommand: terminal.BuildLaunchCommand,
 		IsRunningInTerminal:        isRunningInTerminal,
+		Report: func(ctx context.Context, level, message string, fields map[string]string) {
+			logshipping.Report(ctx, logshipping.CallerCLI, level, message, fields)
+		},
 	}
 }
 
@@ -54,83 +59,95 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 	ctx := cobraCmd.Context()
 	isTerminal := s.IsRunningInTerminal()
 
+	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: starting", nil, sessionID, clientID, "", isTerminal)
+
 	result, err := s.FetchClients(ctx, apiClient, sessionID)
 	if err != nil {
-		reportLauncherError(ctx, "launcher: fetch session details failed", sessionID, clientID, "", isTerminal)
+		s.reportLauncher(ctx, logshipping.LevelError, "launcher: fetch session details failed", err, sessionID, clientID, "", isTerminal)
 		return fmt.Errorf("could not fetch session details: %w", err)
 	}
+	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: session details fetched", nil, sessionID, clientID, "", isTerminal)
 
 	// Portal and Slack show their own "credentials already in use" prompt before
 	// firing the apono:// URI, so a headless (executed from protocol handler) run can trust that. A terminal user typed
 	// the command directly and never saw that prompt - surface it here ourselves.
 	if isTerminal && result.ConsumedBy != "" && result.ConsumedBy != aponoapi.ConsumedByAponoCli {
-		reportLauncherError(ctx, "launcher: credentials already used elsewhere", sessionID, clientID, "", isTerminal)
-		return fmt.Errorf("credentials for this session were already used elsewhere. reset them with `apono access reset-credentials %s` and try again", sessionID)
+		err = fmt.Errorf("credentials for this session were already used elsewhere. reset them with `apono access reset-credentials %s` and try again", sessionID)
+		s.reportLauncher(ctx, logshipping.LevelError, "launcher: credentials already used elsewhere", err, sessionID, clientID, "", isTerminal)
+		return err
 	}
 
 	client, ok := findClient(result.Clients, clientID)
 	if !ok {
-		reportLauncherError(ctx, "launcher: client not supported", sessionID, clientID, "", isTerminal)
-		return fmt.Errorf("client %q is not supported yet.\nSupported clients for this session: %s.\nYou can still copy the connection command and run it manually in your preferred client", clientID, availableIDs(result.Clients))
+		err = fmt.Errorf("client %q is not supported yet.\nSupported clients for this session: %s.\nYou can still copy the connection command and run it manually in your preferred client", clientID, availableIDs(result.Clients))
+		s.reportLauncher(ctx, logshipping.LevelError, "launcher: client not supported", err, sessionID, clientID, "", isTerminal)
+		return err
 	}
 
 	launcherType := client.LauncherType
 	authCommand := strings.TrimSpace(utils.FromNullableString(client.AuthCommand))
 	invocationCommand := client.InvocationCommand
+	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: client resolved", nil, sessionID, clientID, launcherType, isTerminal)
 
 	headlessTerminalLauncher := !isTerminal &&
 		(launcherType == ClientKindTUI || launcherType == ClientKindTERMINAL || launcherType == ClientKindCLI)
 
 	if authCommand != "" && !headlessTerminalLauncher {
-		if err := s.executeCommand(cobraCmd, authCommand); err != nil {
-			reportLauncherError(ctx, "launcher: auth command failed", sessionID, clientID, launcherType, isTerminal)
+		if err = s.executeCommand(cobraCmd, authCommand); err != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: auth command failed", err, sessionID, clientID, launcherType, isTerminal)
 			return err
 		}
 	}
 
 	if strings.Contains(invocationCommand, passwordPlaceholder) {
-		pwd, err := readCachedPassword(sessionID)
-		if err != nil {
-			reportLauncherError(ctx, "launcher: resolve credentials failed", sessionID, clientID, launcherType, isTerminal)
-			return fmt.Errorf("resolve credentials: %w", err)
+		pwd, readErr := readCachedPassword(sessionID)
+		if readErr != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: resolve credentials failed", readErr, sessionID, clientID, launcherType, isTerminal)
+			return fmt.Errorf("resolve credentials: %w", readErr)
 		}
 		invocationCommand = strings.ReplaceAll(invocationCommand, passwordPlaceholder, encodePassword(pwd, client.PasswordEncoding))
 	}
 
+	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: launching client", nil, sessionID, clientID, launcherType, isTerminal)
+
 	switch launcherType {
 	case ClientKindGUI:
-		if err := s.executeCommand(cobraCmd, invocationCommand); err != nil {
-			reportLauncherError(ctx, "launcher: GUI launch failed", sessionID, clientID, launcherType, isTerminal)
+		if err = s.executeCommand(cobraCmd, invocationCommand); err != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: GUI launch failed", err, sessionID, clientID, launcherType, isTerminal)
 			return err
 		}
+		s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: client launched", nil, sessionID, clientID, launcherType, isTerminal)
 		return nil
 
 	case ClientKindTUI, ClientKindTERMINAL, ClientKindCLI:
 		if !headlessTerminalLauncher {
-			if err := s.executeCommand(cobraCmd, invocationCommand); err != nil {
-				reportLauncherError(ctx, "launcher: interactive launch failed", sessionID, clientID, launcherType, isTerminal)
+			if err = s.executeCommand(cobraCmd, invocationCommand); err != nil {
+				s.reportLauncher(ctx, logshipping.LevelError, "launcher: interactive launch failed", err, sessionID, clientID, launcherType, isTerminal)
 				return err
 			}
+			s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: client launched", nil, sessionID, clientID, launcherType, isTerminal)
 			return nil
 		}
 		combined := invocationCommand
 		if authCommand != "" {
 			combined = authCommand + " && " + invocationCommand
 		}
-		wrapped, err := s.BuildTerminalLaunchCommand(combined)
-		if err != nil {
-			reportLauncherError(ctx, "launcher: build terminal launch command failed", sessionID, clientID, launcherType, isTerminal)
-			return fmt.Errorf("build terminal launch command: %w", err)
+		wrapped, wrapErr := s.BuildTerminalLaunchCommand(combined)
+		if wrapErr != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: build terminal launch command failed", wrapErr, sessionID, clientID, launcherType, isTerminal)
+			return fmt.Errorf("build terminal launch command: %w", wrapErr)
 		}
-		if err := s.executeCommand(cobraCmd, wrapped); err != nil {
-			reportLauncherError(ctx, "launcher: headless launch failed", sessionID, clientID, launcherType, isTerminal)
+		if err = s.executeCommand(cobraCmd, wrapped); err != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: headless launch failed", err, sessionID, clientID, launcherType, isTerminal)
 			return err
 		}
+		s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: client launched", nil, sessionID, clientID, launcherType, isTerminal)
 		return nil
 
 	default:
-		reportLauncherError(ctx, "launcher: unknown launcher kind", sessionID, clientID, launcherType, isTerminal)
-		return fmt.Errorf("unknown client kind %q for %q", launcherType, clientID)
+		err = fmt.Errorf("unknown client kind %q for %q", launcherType, clientID)
+		s.reportLauncher(ctx, logshipping.LevelError, "launcher: unknown launcher kind", err, sessionID, clientID, launcherType, isTerminal)
+		return err
 	}
 }
 
@@ -192,11 +209,18 @@ func isRunningInTerminal() bool {
 	return terminal.IsRunning(os.Stdin)
 }
 
-func reportLauncherError(ctx context.Context, message, sessionID, clientID, launcherType string, isTerminal bool) {
-	logshipping.Report(ctx, logshipping.CallerCLI, logshipping.LevelError, message, map[string]string{
+func (s *ClientStarter) reportLauncher(ctx context.Context, level, message string, cause error, sessionID, clientID, launcherType string, isTerminal bool) {
+	if s.Report == nil {
+		return
+	}
+	fields := map[string]string{
 		fieldAccessSessionID: sessionID,
 		fieldClientID:        clientID,
 		fieldLauncherType:    launcherType,
 		fieldIsTerminal:      strconv.FormatBool(isTerminal),
-	})
+	}
+	if cause != nil {
+		fields[fieldError] = cause.Error()
+	}
+	s.Report(ctx, level, message, fields)
 }

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -193,7 +193,7 @@ func isRunningInTerminal() bool {
 }
 
 func reportLauncherError(ctx context.Context, message, sessionID, clientID, launcherType string, isTerminal bool) {
-	logshipping.Report(ctx, logshipping.LevelError, message, map[string]string{
+	logshipping.Report(ctx, logshipping.CallerCLI, logshipping.LevelError, message, map[string]string{
 		fieldAccessSessionID: sessionID,
 		fieldClientID:        clientID,
 		fieldLauncherType:    launcherType,

--- a/pkg/connect/client_starter_test.go
+++ b/pkg/connect/client_starter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/apono-io/apono-cli/pkg/aponoapi"
 	"github.com/apono-io/apono-cli/pkg/clientapi"
+	"github.com/apono-io/apono-cli/pkg/logshipping"
 )
 
 type runShellCall struct {
@@ -64,6 +65,83 @@ func testClientStarter(tty bool, clients []clientapi.LauncherClientModel, consum
 	}
 
 	return s, &runCalls, &wrapCalls
+}
+
+type shippedEntry struct {
+	level   string
+	message string
+	fields  map[string]string
+}
+
+func captureReports(s *ClientStarter) *[]shippedEntry {
+	var entries []shippedEntry
+	s.Report = func(_ context.Context, level, message string, fields map[string]string) {
+		entries = append(entries, shippedEntry{level: level, message: message, fields: fields})
+	}
+	return &entries
+}
+
+func hasEntry(entries []shippedEntry, level, message string) bool {
+	for _, e := range entries {
+		if e.level == level && e.message == message {
+			return true
+		}
+	}
+	return false
+}
+
+func TestStart_failure_shipsRealErrorNotCannedMessage(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("dbeaver", ClientKindGUI, "", "false"),
+	}
+	s, _, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, func() (int, string, error) {
+		return 1, "boom on stderr", nil
+	})
+	entries := captureReports(s)
+
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var errEntry *shippedEntry
+	for i := range *entries {
+		if (*entries)[i].level == logshipping.LevelError && (*entries)[i].message == "launcher: GUI launch failed" {
+			errEntry = &(*entries)[i]
+		}
+	}
+	if errEntry == nil {
+		t.Fatalf("expected a shipped GUI-failure error entry, got %+v", *entries)
+	}
+	if !strings.Contains(errEntry.fields[fieldError], "boom on stderr") {
+		t.Errorf("expected shipped error field to carry the real stderr, got %q", errEntry.fields[fieldError])
+	}
+	if errEntry.fields[fieldAccessSessionID] != "sess-1" || errEntry.fields[fieldClientID] != "dbeaver" {
+		t.Errorf("expected session/client fields, got %+v", errEntry.fields)
+	}
+}
+
+func TestStart_happyPath_shipsInfoStepsIncludingLaunched(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("dbeaver", ClientKindGUI, "", "echo invoke"),
+	}
+	s, _, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
+	entries := captureReports(s)
+
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	for _, msg := range []string{
+		"launcher: starting",
+		"launcher: session details fetched",
+		"launcher: client resolved",
+		"launcher: launching client",
+		"launcher: client launched",
+	} {
+		if !hasEntry(*entries, logshipping.LevelInfo, msg) {
+			t.Errorf("expected INFO step %q to be shipped, entries: %+v", msg, *entries)
+		}
+	}
 }
 
 func TestStart_GUI_runsShellInline_regardlessOfTTY(t *testing.T) {

--- a/pkg/logshipping/logshipping.go
+++ b/pkg/logshipping/logshipping.go
@@ -23,7 +23,9 @@ const (
 	LevelWarn  = "WARN"
 	LevelError = "ERROR"
 
-	callerCLI       = "cli"
+	CallerCLI     = "cli"
+	CallerHandler = "handler"
+
 	fieldCLIVersion = "cli_version"
 	submitTimeout   = 2 * time.Second
 )
@@ -35,7 +37,7 @@ var sessionID = uuid.NewString()
 // No-op when the context lacks an authenticated client (pre-login state).
 // Failures of the underlying API call are silently dropped — telemetry must
 // never affect the user-facing flow.
-func Report(ctx context.Context, level, message string, fields map[string]string) {
+func Report(ctx context.Context, caller, level, message string, fields map[string]string) {
 	client, _ := aponoapi.GetClient(ctx)
 	if client == nil {
 		return
@@ -44,15 +46,18 @@ func Report(ctx context.Context, level, message string, fields map[string]string
 	ctx, cancel := context.WithTimeout(ctx, submitTimeout)
 	defer cancel()
 
-	entry := clientapi.LogEntryClientModel{
+	_ = submit(ctx, client, buildLogEntry(caller, level, message, fields))
+}
+
+func buildLogEntry(caller, level, message string, fields map[string]string) clientapi.LogEntryClientModel {
+	return clientapi.LogEntryClientModel{
 		SessionId: sessionID,
 		Level:     level,
 		Message:   message,
-		Caller:    getCaller(),
+		Caller:    newCaller(caller),
 		Timestamp: getTimestamp(),
 		Fields:    withCLIVersion(fields),
 	}
-	_ = submit(ctx, client, entry)
 }
 
 // withCLIVersion returns a copy of fields with the CLI build version added,
@@ -71,9 +76,8 @@ func submit(ctx context.Context, client *aponoapi.AponoClient, entry clientapi.L
 	return err
 }
 
-func getCaller() clientapi.NullableString {
-	c := callerCLI
-	return *clientapi.NewNullableString(&c)
+func newCaller(caller string) clientapi.NullableString {
+	return *clientapi.NewNullableString(&caller)
 }
 
 func getTimestamp() clientapi.NullableFloat64 {

--- a/pkg/logshipping/logshipping_test.go
+++ b/pkg/logshipping/logshipping_test.go
@@ -1,0 +1,38 @@
+package logshipping
+
+import "testing"
+
+func TestBuildLogEntry_threadsCallerLevelMessageAndFields(t *testing.T) {
+	entry := buildLogEntry(CallerHandler, LevelError, "boom", map[string]string{"k": "v"})
+
+	if got := entry.GetCaller(); got != CallerHandler {
+		t.Errorf("caller = %q, want %q", got, CallerHandler)
+	}
+	if entry.Level != LevelError {
+		t.Errorf("level = %q, want %q", entry.Level, LevelError)
+	}
+	if entry.Message != "boom" {
+		t.Errorf("message = %q, want %q", entry.Message, "boom")
+	}
+	if entry.Fields["k"] != "v" {
+		t.Errorf("fields[k] = %q, want %q", entry.Fields["k"], "v")
+	}
+	if _, ok := entry.Fields[fieldCLIVersion]; !ok {
+		t.Errorf("expected %q field to be present", fieldCLIVersion)
+	}
+	if entry.SessionId != sessionID {
+		t.Errorf("session id = %q, want %q", entry.SessionId, sessionID)
+	}
+}
+
+func TestWithCLIVersion_doesNotMutateInput(t *testing.T) {
+	in := map[string]string{"a": "1"}
+	out := withCLIVersion(in)
+
+	if _, ok := in[fieldCLIVersion]; ok {
+		t.Errorf("input map was mutated with %q", fieldCLIVersion)
+	}
+	if out["a"] != "1" {
+		t.Errorf("out[a] = %q, want %q", out["a"], "1")
+	}
+}

--- a/pkg/urihandler/drain.go
+++ b/pkg/urihandler/drain.go
@@ -49,7 +49,7 @@ func DrainLog(path string) ([]LogLine, error) {
 		return nil, nil
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/urihandler/drain.go
+++ b/pkg/urihandler/drain.go
@@ -1,0 +1,83 @@
+package urihandler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apono-io/apono-cli/pkg/logshipping"
+)
+
+const (
+	handlerLogFileName = "handler.log"
+	logLineSeparator   = "\t"
+	maxDrainBytes      = 64 * 1024
+	truncationNotice   = "handler log truncated: dropped oldest lines over size cap"
+)
+
+// LogLine is one parsed record drained from the handler log file. Its Level is
+// whatever level string the script wrote (INFO/ERROR), passed through verbatim.
+type LogLine struct {
+	Level   string
+	Message string
+}
+
+// HandlerLogPath returns the file the apono:// handler script writes its trace
+// to — the same directory that holds the handler bundle.
+func HandlerLogPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, bundleParentDir, handlerLogFileName), nil
+}
+
+// DrainLog reads the handler log at path, empties it, and returns the parsed
+// lines. No-op (nil, nil) when the file is missing or empty. The file is emptied
+// as soon as it is read, so the caller must be able to ship what it receives —
+// callers guard this by only invoking DrainLog once an authenticated client is
+// present.
+func DrainLog(path string) ([]LogLine, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if info.Size() == 0 {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		return nil, err
+	}
+
+	return parseLines(data), nil
+}
+
+func parseLines(data []byte) []LogLine {
+	var lines []LogLine
+	if len(data) > maxDrainBytes {
+		data = data[len(data)-maxDrainBytes:]
+		lines = append(lines, LogLine{Level: logshipping.LevelWarn, Message: truncationNotice})
+	}
+
+	for _, raw := range strings.Split(string(data), "\n") {
+		raw = strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		level, message, found := strings.Cut(raw, logLineSeparator)
+		if !found {
+			lines = append(lines, LogLine{Level: logshipping.LevelInfo, Message: raw})
+			continue
+		}
+		lines = append(lines, LogLine{Level: level, Message: message})
+	}
+	return lines
+}

--- a/pkg/urihandler/drain_test.go
+++ b/pkg/urihandler/drain_test.go
@@ -1,0 +1,90 @@
+package urihandler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/apono-io/apono-cli/pkg/logshipping"
+)
+
+func writeLog(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "handler.log")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	return path
+}
+
+func TestDrainLog_missingFile_isNoop(t *testing.T) {
+	lines, err := DrainLog(filepath.Join(t.TempDir(), "absent.log"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lines != nil {
+		t.Errorf("expected nil lines for missing file, got %v", lines)
+	}
+}
+
+func TestDrainLog_emptyFile_isNoop(t *testing.T) {
+	path := writeLog(t, "")
+	lines, err := DrainLog(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lines != nil {
+		t.Errorf("expected nil lines for empty file, got %v", lines)
+	}
+}
+
+func TestDrainLog_parsesLinesAndEmptiesFile(t *testing.T) {
+	path := writeLog(t, "INFO\treceived launch request\nERROR\tapono CLI not found code=127\n")
+
+	lines, err := DrainLog(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != (LogLine{Level: logshipping.LevelInfo, Message: "received launch request"}) {
+		t.Errorf("line 0 = %+v", lines[0])
+	}
+	if lines[1] != (LogLine{Level: logshipping.LevelError, Message: "apono CLI not found code=127"}) {
+		t.Errorf("line 1 = %+v", lines[1])
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected file emptied after drain, still has %d bytes", len(data))
+	}
+}
+
+func TestDrainLog_malformedLineDefaultsToInfo(t *testing.T) {
+	path := writeLog(t, "no tab in this line\n")
+	lines, err := DrainLog(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) != 1 || lines[0].Level != logshipping.LevelInfo || lines[0].Message != "no tab in this line" {
+		t.Errorf("expected INFO fallback with raw message, got %+v", lines)
+	}
+}
+
+func TestDrainLog_overCapPrependsTruncationNotice(t *testing.T) {
+	body := strings.Repeat("INFO\tx\n", (maxDrainBytes/7)+100) // 7 bytes per line, well over cap
+	path := writeLog(t, body)
+
+	lines, err := DrainLog(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(lines) == 0 || lines[0].Level != logshipping.LevelWarn || !strings.Contains(lines[0].Message, "truncated") {
+		t.Fatalf("expected first line to be a WARN truncation notice, got %+v", lines[0])
+	}
+}

--- a/pkg/urihandler/drain_test.go
+++ b/pkg/urihandler/drain_test.go
@@ -56,7 +56,7 @@ func TestDrainLog_parsesLinesAndEmptiesFile(t *testing.T) {
 		t.Errorf("line 1 = %+v", lines[1])
 	}
 
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path))
 	if err != nil {
 		t.Fatalf("read back: %v", err)
 	}

--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -32,11 +32,11 @@ func TestHandlerShellTemplate_invokesPATHResolvedApono(t *testing.T) {
 func TestHandlerShellTemplate_writesTraceAndFailureContext(t *testing.T) {
 	wantSubstrings := []string{
 		filepath.Join(bundleParentDir, handlerLogFileName), // log path agrees with HandlerLogPath
-		"log INFO",                                         // step logging
-		"command -v apono",                                 // explicit resolve check before exec
-		"trap",                                             // failure backstop
-		"PATH=$PATH",                                       // PATH captured on failure
-		"exec apono access use",                            // still hands off to the CLI
+		"log INFO",              // step logging
+		"command -v apono",      // explicit resolve check before exec
+		"trap",                  // failure backstop
+		"PATH=$PATH",            // PATH captured on failure
+		"exec apono access use", // still hands off to the CLI
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(handlerShellTemplate, want) {

--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -2,6 +2,9 @@ package urihandler
 
 import (
 	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -24,6 +27,91 @@ func TestHandlerShellTemplate_invokesPATHResolvedApono(t *testing.T) {
 	if strings.Contains(handlerShellTemplate, "__APONO_BINARY__") {
 		t.Errorf("handler.sh should not contain __APONO_BINARY__ placeholder (uses PATH-resolved apono now), got:\n%s", handlerShellTemplate)
 	}
+}
+
+func TestHandlerShellTemplate_writesTraceAndFailureContext(t *testing.T) {
+	wantSubstrings := []string{
+		filepath.Join(bundleParentDir, handlerLogFileName), // log path agrees with HandlerLogPath
+		"log INFO",                                         // step logging
+		"command -v apono",                                 // explicit resolve check before exec
+		"trap",                                             // failure backstop
+		"PATH=$PATH",                                       // PATH captured on failure
+		"exec apono access use",                            // still hands off to the CLI
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(handlerShellTemplate, want) {
+			t.Errorf("expected handler.sh to contain %q, got:\n%s", want, handlerShellTemplate)
+		}
+	}
+}
+
+// runHandler runs the embedded script under zsh with a controlled HOME and
+// PATH, and returns the drained log lines. Skips where zsh is absent (keeps
+// non-macOS CI green) — no executable fixture is created, so the gosec file-perm
+// rule is never engaged.
+func runHandler(t *testing.T, uri, pathEnv string) []LogLine {
+	t.Helper()
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not available")
+	}
+
+	home := t.TempDir()
+	logDir := filepath.Join(home, bundleParentDir)
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	scriptPath := filepath.Join(t.TempDir(), "handler.sh")
+	if err := os.WriteFile(scriptPath, []byte(handlerShellTemplate), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cmd := exec.Command(zsh, scriptPath, uri)
+	cmd.Env = []string{"HOME=" + home, "PATH=" + pathEnv}
+	_ = cmd.Run() // non-zero exit is expected on the failure paths
+
+	lines, err := DrainLog(filepath.Join(logDir, handlerLogFileName))
+	if err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	return lines
+}
+
+func TestHandlerShell_badURI_logsInvalidLaunchURL(t *testing.T) {
+	if runtime.GOOS != utils.DarwinOS {
+		// The script logic is portable, but run it only where launches actually
+		// happen to avoid depending on a Linux zsh being present/configured.
+		t.Skip("handler execution test runs on macOS")
+	}
+	lines := runHandler(t, "apono://wrong", "/usr/bin:/bin")
+
+	if !containsMessage(lines, "invalid launch URL") || !containsMessage(lines, "code=64") {
+		t.Errorf("expected an ERROR line for the bad URI, got %+v", lines)
+	}
+}
+
+func TestHandlerShell_aponoMissing_logsNotFoundWithPATH(t *testing.T) {
+	if runtime.GOOS != utils.DarwinOS {
+		t.Skip("handler execution test runs on macOS")
+	}
+	// Valid URI, but a PATH deliberately without apono.
+	lines := runHandler(t, "apono://connect?session=s&account=a&client=dbeaver", "/usr/bin:/bin")
+
+	if !containsMessage(lines, "received launch request") {
+		t.Errorf("expected the initial INFO step, got %+v", lines)
+	}
+	if !containsMessage(lines, "apono CLI not found") || !containsMessage(lines, "code=127") {
+		t.Errorf("expected an ERROR line for missing apono, got %+v", lines)
+	}
+}
+
+func containsMessage(lines []LogLine, substr string) bool {
+	for _, l := range lines {
+		if strings.Contains(l.Message, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRegister_rejectsNonDarwin(t *testing.T) {

--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -2,8 +2,6 @@ package urihandler
 
 import (
 	"bytes"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -43,74 +41,6 @@ func TestHandlerShellTemplate_writesTraceAndFailureContext(t *testing.T) {
 			t.Errorf("expected handler.sh to contain %q, got:\n%s", want, handlerShellTemplate)
 		}
 	}
-}
-
-// zshPath is the macOS system zsh. Kept a constant so gosec (G204) accepts the
-// subprocess launch; callers gate these tests on macOS, where /bin/zsh always exists.
-const zshPath = "/bin/zsh"
-
-// runHandler runs the embedded script under /bin/zsh with a controlled HOME and
-// PATH, and returns the drained log lines. Callers gate on macOS; no executable
-// fixture is created, so the gosec file-perm rule is never engaged.
-func runHandler(t *testing.T, uri, pathEnv string) []LogLine {
-	t.Helper()
-
-	home := t.TempDir()
-	logDir := filepath.Join(home, bundleParentDir)
-	if err := os.MkdirAll(logDir, 0o700); err != nil {
-		t.Fatalf("mkdir log dir: %v", err)
-	}
-	scriptPath := filepath.Join(t.TempDir(), "handler.sh")
-	if err := os.WriteFile(scriptPath, []byte(handlerShellTemplate), 0o600); err != nil {
-		t.Fatalf("write script: %v", err)
-	}
-
-	cmd := exec.Command(zshPath, scriptPath, uri)
-	cmd.Env = []string{"HOME=" + home, "PATH=" + pathEnv}
-	_ = cmd.Run() // non-zero exit is expected on the failure paths
-
-	lines, err := DrainLog(filepath.Join(logDir, handlerLogFileName))
-	if err != nil {
-		t.Fatalf("drain: %v", err)
-	}
-	return lines
-}
-
-func TestHandlerShell_badURI_logsInvalidLaunchURL(t *testing.T) {
-	if runtime.GOOS != utils.DarwinOS {
-		// The script logic is portable, but run it only where launches actually
-		// happen to avoid depending on a Linux zsh being present/configured.
-		t.Skip("handler execution test runs on macOS")
-	}
-	lines := runHandler(t, "apono://wrong", "/usr/bin:/bin")
-
-	if !containsMessage(lines, "invalid launch URL") || !containsMessage(lines, "code=64") {
-		t.Errorf("expected an ERROR line for the bad URI, got %+v", lines)
-	}
-}
-
-func TestHandlerShell_aponoMissing_logsNotFoundWithPATH(t *testing.T) {
-	if runtime.GOOS != utils.DarwinOS {
-		t.Skip("handler execution test runs on macOS")
-	}
-	// Valid URI, but a PATH deliberately without apono.
-	lines := runHandler(t, "apono://connect?session=s&account=a&client=dbeaver", "/usr/bin:/bin")
-
-	if !containsMessage(lines, "received launch request") {
-		t.Errorf("expected the initial INFO step, got %+v", lines)
-	}
-	if !containsMessage(lines, "apono CLI not found") || !containsMessage(lines, "code=127") {
-		t.Errorf("expected an ERROR line for missing apono, got %+v", lines)
-	}
-}
-
-func containsMessage(lines []LogLine, substr string) bool {
-	for _, l := range lines {
-		if strings.Contains(l.Message, substr) {
-			return true
-		}
-	}
-	return false
 }
 
 func TestRegister_rejectsNonDarwin(t *testing.T) {

--- a/pkg/urihandler/register_test.go
+++ b/pkg/urihandler/register_test.go
@@ -45,16 +45,15 @@ func TestHandlerShellTemplate_writesTraceAndFailureContext(t *testing.T) {
 	}
 }
 
-// runHandler runs the embedded script under zsh with a controlled HOME and
-// PATH, and returns the drained log lines. Skips where zsh is absent (keeps
-// non-macOS CI green) — no executable fixture is created, so the gosec file-perm
-// rule is never engaged.
+// zshPath is the macOS system zsh. Kept a constant so gosec (G204) accepts the
+// subprocess launch; callers gate these tests on macOS, where /bin/zsh always exists.
+const zshPath = "/bin/zsh"
+
+// runHandler runs the embedded script under /bin/zsh with a controlled HOME and
+// PATH, and returns the drained log lines. Callers gate on macOS; no executable
+// fixture is created, so the gosec file-perm rule is never engaged.
 func runHandler(t *testing.T, uri, pathEnv string) []LogLine {
 	t.Helper()
-	zsh, err := exec.LookPath("zsh")
-	if err != nil {
-		t.Skip("zsh not available")
-	}
 
 	home := t.TempDir()
 	logDir := filepath.Join(home, bundleParentDir)
@@ -66,7 +65,7 @@ func runHandler(t *testing.T, uri, pathEnv string) []LogLine {
 		t.Fatalf("write script: %v", err)
 	}
 
-	cmd := exec.Command(zsh, scriptPath, uri)
+	cmd := exec.Command(zshPath, scriptPath, uri)
 	cmd.Env = []string{"HOME=" + home, "PATH=" + pathEnv}
 	_ = cmd.Run() // non-zero exit is expected on the failure paths
 

--- a/pkg/urihandler/scripts/handler.sh
+++ b/pkg/urihandler/scripts/handler.sh
@@ -1,6 +1,23 @@
 #!/bin/zsh
 set -e
+
+logfile="${HOME}/Library/Application Support/apono-cli/handler.log"
+log() { print -r -- "$1"$'\t'"$2" >> "$logfile" 2>/dev/null || true }
+
+trap '
+  code=$?
+  if [[ $code -ne 0 ]]; then
+    case $code in
+      64)  reason="invalid launch URL" ;;
+      127) reason="apono CLI not found on PATH" ;;
+      *)   reason="handler failed" ;;
+    esac
+    log ERROR "$reason code=$code apono=$(command -v apono 2>/dev/null || echo MISSING) PATH=$PATH"
+  fi
+' EXIT
+
 uri="$1"
+log INFO "received launch request"
 if [[ -z "$uri" ]]; then
   echo "missing URI argument" >&2
   exit 64
@@ -26,5 +43,11 @@ if [[ "$session$account$client" == *%* ]]; then
   echo "URL-encoded characters not supported in launch params" >&2
   exit 64
 fi
+log INFO "parsed launch params session=$session account=$account client=$client"
+if ! command -v apono >/dev/null 2>&1; then
+  echo "apono CLI not found on PATH" >&2
+  exit 127
+fi
+log INFO "apono resolved at $(command -v apono); handing off to access use"
 export _APONO_ACCOUNT_ID_="$account"
 exec apono access use "$session" --client "$client" >/dev/null


### PR DESCRIPTION
## Summary

When a session launch from the portal or Slack silently fails, we currently can't tell why. This adds diagnostics along the launch path: each step is reported, failures now carry the real error instead of a generic message, and the macOS helper that opens the link records what it did — and why it stopped, if it couldn't start the CLI — for the CLI to forward on its next run.
