### PR TITLE
Fix interactive connect failing on one-time database credentials

### DIFF
--- a/pkg/commands/access/actions/use.go
+++ b/pkg/commands/access/actions/use.go
@@ -73,7 +73,7 @@ func AccessDetails() *cobra.Command {
 			}
 
 			if cmd.Flags().Changed(clientFlagName) {
-				err = connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID)
+				err = connect.NewClientStarter().Start(cmd, client, session.Id, cmdFlags.clientID, nil)
 				if err != nil {
 					return err
 				}

--- a/pkg/connect/access_session.go
+++ b/pkg/connect/access_session.go
@@ -15,7 +15,11 @@ type ClientFetchResult struct {
 	ConsumedBy string
 }
 
-func FetchClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID string) (*ClientFetchResult, error) {
+// FetchAccessDetails performs the single credential-consuming access-details
+// fetch for a session. The backend hands out the one-time password on the first
+// call and deletes it, so this must be called exactly once per connect and its
+// result reused for everything that follows.
+func FetchAccessDetails(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID string) (*clientapi.AccessSessionDetailsClientModel, error) {
 	details, _, err := apiClient.ClientAPI.AccessSessionsAPI.
 		GetAccessSessionAccessDetails(ctx, sessionID).
 		ConsumedBy(aponoapi.ConsumedByAponoCli).
@@ -23,6 +27,14 @@ func FetchClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionI
 	if err != nil {
 		return nil, err
 	}
+	return details, nil
+}
+
+// BuildClientFetchResult projects already-fetched access details into the
+// launcher list (appending the cli command as a client). It does not fetch —
+// callers that already hold details reuse them here instead of consuming the
+// one-time password a second time.
+func BuildClientFetchResult(details *clientapi.AccessSessionDetailsClientModel) *ClientFetchResult {
 	clients := details.Launchers
 	if cli := utils.FromNullableString(details.Cli); cli != "" {
 		clients = append(clients, clientapi.LauncherClientModel{
@@ -34,5 +46,16 @@ func FetchClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionI
 	return &ClientFetchResult{
 		Clients:    clients,
 		ConsumedBy: utils.FromNullableString(details.ConsumedBy),
-	}, nil
+	}
+}
+
+// FetchClients fetches a session's access details and projects them into the
+// launcher list. Callers that already hold details should use
+// FetchAccessDetails + BuildClientFetchResult to avoid a second consuming fetch.
+func FetchClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID string) (*ClientFetchResult, error) {
+	details, err := FetchAccessDetails(ctx, apiClient, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	return BuildClientFetchResult(details), nil
 }

--- a/pkg/connect/access_session.go
+++ b/pkg/connect/access_session.go
@@ -15,10 +15,6 @@ type ClientFetchResult struct {
 	ConsumedBy string
 }
 
-// FetchAccessDetails performs the single credential-consuming access-details
-// fetch for a session. The backend hands out the one-time password on the first
-// call and deletes it, so this must be called exactly once per connect and its
-// result reused for everything that follows.
 func FetchAccessDetails(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID string) (*clientapi.AccessSessionDetailsClientModel, error) {
 	details, _, err := apiClient.ClientAPI.AccessSessionsAPI.
 		GetAccessSessionAccessDetails(ctx, sessionID).
@@ -30,10 +26,6 @@ func FetchAccessDetails(ctx context.Context, apiClient *aponoapi.AponoClient, se
 	return details, nil
 }
 
-// BuildClientFetchResult projects already-fetched access details into the
-// launcher list (appending the cli command as a client). It does not fetch —
-// callers that already hold details reuse them here instead of consuming the
-// one-time password a second time.
 func BuildClientFetchResult(details *clientapi.AccessSessionDetailsClientModel) *ClientFetchResult {
 	clients := details.Launchers
 	if cli := utils.FromNullableString(details.Cli); cli != "" {
@@ -49,9 +41,6 @@ func BuildClientFetchResult(details *clientapi.AccessSessionDetailsClientModel) 
 	}
 }
 
-// FetchClients fetches a session's access details and projects them into the
-// launcher list. Callers that already hold details should use
-// FetchAccessDetails + BuildClientFetchResult to avoid a second consuming fetch.
 func FetchClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID string) (*ClientFetchResult, error) {
 	details, err := FetchAccessDetails(ctx, apiClient, sessionID)
 	if err != nil {

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -55,10 +55,6 @@ func NewClientStarter() *ClientStarter {
 	}
 }
 
-// resolveClients returns the launcher list for the session: the caller's
-// prefetched result when supplied (the interactive flow's single consuming
-// fetch), otherwise a fresh fetch. Kept separate so Start stays within the
-// cyclomatic-complexity limit.
 func (s *ClientStarter) resolveClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID, clientID string, isTerminal bool, prefetched *ClientFetchResult) (*ClientFetchResult, error) {
 	if prefetched != nil {
 		return prefetched, nil
@@ -72,10 +68,6 @@ func (s *ClientStarter) resolveClients(ctx context.Context, apiClient *aponoapi.
 	return result, nil
 }
 
-// Start launches the session in the requested client. When prefetched is
-// non-nil it is reused (the interactive flow passes the result of its single
-// consuming fetch); when nil, Start fetches once itself (the direct
-// `apono access use --client X` path, which has no prior fetch).
 func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.AponoClient, sessionID, clientID string, prefetched *ClientFetchResult) error {
 	ctx := cobraCmd.Context()
 	isTerminal := s.IsRunningInTerminal()

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -55,6 +55,23 @@ func NewClientStarter() *ClientStarter {
 	}
 }
 
+// resolveClients returns the launcher list for the session: the caller's
+// prefetched result when supplied (the interactive flow's single consuming
+// fetch), otherwise a fresh fetch. Kept separate so Start stays within the
+// cyclomatic-complexity limit.
+func (s *ClientStarter) resolveClients(ctx context.Context, apiClient *aponoapi.AponoClient, sessionID, clientID string, isTerminal bool, prefetched *ClientFetchResult) (*ClientFetchResult, error) {
+	if prefetched != nil {
+		return prefetched, nil
+	}
+	result, err := s.FetchClients(ctx, apiClient, sessionID)
+	if err != nil {
+		s.reportLauncher(ctx, logshipping.LevelError, "launcher: fetch session details failed", err, sessionID, clientID, "", isTerminal)
+		return nil, fmt.Errorf("could not fetch session details: %w", err)
+	}
+	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: session details fetched", nil, sessionID, clientID, "", isTerminal)
+	return result, nil
+}
+
 // Start launches the session in the requested client. When prefetched is
 // non-nil it is reused (the interactive flow passes the result of its single
 // consuming fetch); when nil, Start fetches once itself (the direct
@@ -65,15 +82,9 @@ func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.Apono
 
 	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: starting", nil, sessionID, clientID, "", isTerminal)
 
-	result := prefetched
-	var err error
-	if result == nil {
-		result, err = s.FetchClients(ctx, apiClient, sessionID)
-		if err != nil {
-			s.reportLauncher(ctx, logshipping.LevelError, "launcher: fetch session details failed", err, sessionID, clientID, "", isTerminal)
-			return fmt.Errorf("could not fetch session details: %w", err)
-		}
-		s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: session details fetched", nil, sessionID, clientID, "", isTerminal)
+	result, err := s.resolveClients(ctx, apiClient, sessionID, clientID, isTerminal, prefetched)
+	if err != nil {
+		return err
 	}
 
 	// Portal and Slack show their own "credentials already in use" prompt before

--- a/pkg/connect/client_starter.go
+++ b/pkg/connect/client_starter.go
@@ -55,18 +55,26 @@ func NewClientStarter() *ClientStarter {
 	}
 }
 
-func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.AponoClient, sessionID, clientID string) error {
+// Start launches the session in the requested client. When prefetched is
+// non-nil it is reused (the interactive flow passes the result of its single
+// consuming fetch); when nil, Start fetches once itself (the direct
+// `apono access use --client X` path, which has no prior fetch).
+func (s *ClientStarter) Start(cobraCmd *cobra.Command, apiClient *aponoapi.AponoClient, sessionID, clientID string, prefetched *ClientFetchResult) error {
 	ctx := cobraCmd.Context()
 	isTerminal := s.IsRunningInTerminal()
 
 	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: starting", nil, sessionID, clientID, "", isTerminal)
 
-	result, err := s.FetchClients(ctx, apiClient, sessionID)
-	if err != nil {
-		s.reportLauncher(ctx, logshipping.LevelError, "launcher: fetch session details failed", err, sessionID, clientID, "", isTerminal)
-		return fmt.Errorf("could not fetch session details: %w", err)
+	result := prefetched
+	var err error
+	if result == nil {
+		result, err = s.FetchClients(ctx, apiClient, sessionID)
+		if err != nil {
+			s.reportLauncher(ctx, logshipping.LevelError, "launcher: fetch session details failed", err, sessionID, clientID, "", isTerminal)
+			return fmt.Errorf("could not fetch session details: %w", err)
+		}
+		s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: session details fetched", nil, sessionID, clientID, "", isTerminal)
 	}
-	s.reportLauncher(ctx, logshipping.LevelInfo, "launcher: session details fetched", nil, sessionID, clientID, "", isTerminal)
 
 	// Portal and Slack show their own "credentials already in use" prompt before
 	// firing the apono:// URI, so a headless (executed from protocol handler) run can trust that. A terminal user typed

--- a/pkg/connect/client_starter_test.go
+++ b/pkg/connect/client_starter_test.go
@@ -90,6 +90,51 @@ func hasEntry(entries []shippedEntry, level, message string) bool {
 	return false
 }
 
+func TestStart_prefetchedResult_doesNotFetchAgain(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("dbeaver", ClientKindGUI, "", "echo invoke"),
+	}
+	s, runs, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
+
+	fetchCalls := 0
+	s.FetchClients = func(_ context.Context, _ *aponoapi.AponoClient, _ string) (*ClientFetchResult, error) {
+		fetchCalls++
+		return nil, errors.New("FetchClients must not be called when a prefetched result is supplied")
+	}
+
+	prefetched := &ClientFetchResult{Clients: clients, ConsumedBy: aponoapi.ConsumedByAponoCli}
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", prefetched); err != nil {
+		t.Fatalf("Start with prefetched result returned error: %v", err)
+	}
+
+	if fetchCalls != 0 {
+		t.Errorf("expected no FetchClients calls when prefetched result supplied, got %d", fetchCalls)
+	}
+	if len(*runs) != 1 {
+		t.Errorf("expected 1 runShell call (invocation) from the prefetched launcher, got %d", len(*runs))
+	}
+}
+
+func TestStart_nilPrefetched_fetchesOnce(t *testing.T) {
+	clients := []clientapi.LauncherClientModel{
+		newClientModel("dbeaver", ClientKindGUI, "", "echo invoke"),
+	}
+	s, _, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
+
+	fetchCalls := 0
+	s.FetchClients = func(_ context.Context, _ *aponoapi.AponoClient, _ string) (*ClientFetchResult, error) {
+		fetchCalls++
+		return &ClientFetchResult{Clients: clients, ConsumedBy: aponoapi.ConsumedByAponoCli}, nil
+	}
+
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Errorf("expected exactly 1 FetchClients call for the direct (nil prefetched) path, got %d", fetchCalls)
+	}
+}
+
 func TestStart_failure_shipsRealErrorNotCannedMessage(t *testing.T) {
 	clients := []clientapi.LauncherClientModel{
 		newClientModel("dbeaver", ClientKindGUI, "", "false"),
@@ -99,7 +144,7 @@ func TestStart_failure_shipsRealErrorNotCannedMessage(t *testing.T) {
 	})
 	entries := captureReports(s)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err == nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 
@@ -127,7 +172,7 @@ func TestStart_happyPath_shipsInfoStepsIncludingLaunched(t *testing.T) {
 	s, _, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
 	entries := captureReports(s)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 
@@ -161,7 +206,7 @@ func TestStart_GUI_runsShellInline_regardlessOfTTY(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s, runs, wraps := testClientStarter(tc.tty, clients, aponoapi.ConsumedByAponoCli, nil)
 
-			err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver")
+			err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil)
 			if err != nil {
 				t.Fatalf("Start returned error: %v", err)
 			}
@@ -190,7 +235,7 @@ func TestStart_TUI_TTY_runsInline(t *testing.T) {
 			}
 			s, runs, wraps := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
 
-			if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s"); err != nil {
+			if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s", nil); err != nil {
 				t.Fatalf("Start returned error: %v", err)
 			}
 
@@ -217,7 +262,7 @@ func TestStart_TUI_NoTTY_wrapsAuthAndInvocationTogether(t *testing.T) {
 			}
 			s, runs, wraps := testClientStarter(false, clients, aponoapi.ConsumedByAponoCli, nil)
 
-			if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s"); err != nil {
+			if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s", nil); err != nil {
 				t.Fatalf("Start returned error: %v", err)
 			}
 
@@ -246,7 +291,7 @@ func TestStart_TUI_NoTTY_wrapBuilderFails_returnsWrappedError(t *testing.T) {
 		return "", errors.New("osascript path missing")
 	}
 
-	err := s.Start(newCobraCmd(), nil, "sess-1", "k9s")
+	err := s.Start(newCobraCmd(), nil, "sess-1", "k9s", nil)
 	if err == nil {
 		t.Fatal("expected error when BuildTerminalLaunchCommand fails, got nil")
 	}
@@ -267,7 +312,7 @@ func TestStart_TUI_NoTTY_emptyAuth_wrapsInvocationOnly(t *testing.T) {
 	}
 	s, runs, wraps := testClientStarter(false, clients, aponoapi.ConsumedByAponoCli, nil)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "k9s", nil); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 
@@ -290,7 +335,7 @@ func TestStart_unknownClient_errorsWithAvailableList(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
 
-	err := s.Start(newCobraCmd(), nil, "sess-1", "nonexistent")
+	err := s.Start(newCobraCmd(), nil, "sess-1", "nonexistent", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown client, got nil")
 	}
@@ -315,7 +360,7 @@ func TestStart_shellNonZeroExit_returnsErrorWithStderr(t *testing.T) {
 		return 1, "boom on stderr", nil
 	})
 
-	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver")
+	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil)
 	if err == nil {
 		t.Fatal("expected error on non-zero exit, got nil")
 	}
@@ -333,7 +378,7 @@ func TestStart_TTY_consumedByOther_blocks(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, clients, "someone-else", nil)
 
-	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver")
+	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil)
 	if err == nil {
 		t.Fatal("expected error when creds consumed elsewhere in TTY context, got nil")
 	}
@@ -352,7 +397,7 @@ func TestStart_NoTTY_consumedByOther_proceeds(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(false, clients, "someone-else", nil)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err != nil {
 		t.Fatalf("expected success in headless context regardless of consumedBy, got %v", err)
 	}
 	if len(*runs) != 1 {
@@ -366,7 +411,7 @@ func TestStart_TTY_consumedByEmpty_proceeds(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, clients, "", nil)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err != nil {
 		t.Fatalf("expected success when consumedBy is empty (fresh session), got %v", err)
 	}
 	if len(*runs) != 1 {
@@ -412,7 +457,7 @@ func TestStart_substitutesPasswordPlaceholder_withURLEncoding(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, []clientapi.LauncherClientModel{tableplus}, aponoapi.ConsumedByAponoCli, nil)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "tableplus"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "tableplus", nil); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 	if len(*runs) != 1 {
@@ -438,7 +483,7 @@ func TestStart_noPlaceholder_skipsCacheRead(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, clients, aponoapi.ConsumedByAponoCli, nil)
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 	if len(*runs) != 2 {
@@ -457,7 +502,7 @@ func TestStart_placeholderButCacheMissing_returnsError(t *testing.T) {
 	}
 	s, runs, _ := testClientStarter(true, []clientapi.LauncherClientModel{tableplus}, aponoapi.ConsumedByAponoCli, nil)
 
-	err := s.Start(newCobraCmd(), nil, "sess-missing", "tableplus")
+	err := s.Start(newCobraCmd(), nil, "sess-missing", "tableplus", nil)
 	if err == nil {
 		t.Fatal("expected error when cache file missing, got nil")
 	}
@@ -482,7 +527,7 @@ func TestStart_authFails_invocationSkipped(t *testing.T) {
 		return 0, "", nil
 	})
 
-	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver")
+	err := s.Start(newCobraCmd(), nil, "sess-1", "dbeaver", nil)
 	if err == nil {
 		t.Fatal("expected error when auth_command fails, got nil")
 	}
@@ -519,7 +564,7 @@ func TestStart_authFirstThenSubstitution(t *testing.T) {
 		return 0, "", nil
 	})
 
-	if err := s.Start(newCobraCmd(), nil, "sess-1", "tableplus"); err != nil {
+	if err := s.Start(newCobraCmd(), nil, "sess-1", "tableplus", nil); err != nil {
 		t.Fatalf("Start returned error: %v", err)
 	}
 	if len(*runs) != 2 {

--- a/pkg/interactive/flows/use_session.go
+++ b/pkg/interactive/flows/use_session.go
@@ -41,9 +41,6 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		return nil
 	}
 
-	// Single credential-consuming fetch for the whole interactive connect. The
-	// backend deletes the one-time password on this first call, so every branch
-	// below reuses this result instead of fetching (and consuming) again.
 	details, err := connect.FetchAccessDetails(cmd.Context(), client, session.Id)
 	if err != nil {
 		return err
@@ -103,10 +100,6 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 	}
 }
 
-// printSessionInstructions renders and prints a session's instructions. When
-// details is non-nil it reuses that already-fetched result (interactive flow's
-// single consuming fetch); when nil it fetches once itself (the single
-// connection-method path, which has no prior fetch).
 func printSessionInstructions(cmd *cobra.Command, client *aponoapi.AponoClient, session *clientapi.AccessSessionClientModel, details *clientapi.AccessSessionDetailsClientModel) error {
 	var accessDetails string
 	var customInstructionMessage services.CustomInstructionMessage

--- a/pkg/interactive/flows/use_session.go
+++ b/pkg/interactive/flows/use_session.go
@@ -33,7 +33,7 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 	}
 
 	if len(session.ConnectionMethods) == 1 {
-		err = printSessionInstructions(cmd, client, session)
+		err = printSessionInstructions(cmd, client, session, nil)
 		if err != nil {
 			return err
 		}
@@ -41,14 +41,21 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		return nil
 	}
 
+	// Single credential-consuming fetch for the whole interactive connect. The
+	// backend deletes the one-time password on this first call, so every branch
+	// below reuses this result instead of fetching (and consuming) again.
+	details, err := connect.FetchAccessDetails(cmd.Context(), client, session.Id)
+	if err != nil {
+		return err
+	}
+	result := connect.BuildClientFetchResult(details)
+
 	connectWithAppAvailable := false
 	var guiTuiInstalled []clientapi.LauncherClientModel
 	if runtime.GOOS == utils.DarwinOS {
-		if result, fetchErr := connect.FetchClients(cmd.Context(), client, session.Id); fetchErr == nil {
-			for _, c := range result.Clients {
-				if (c.LauncherType == connect.ClientKindGUI || c.LauncherType == connect.ClientKindTUI) && connect.IsInstalled(c) {
-					guiTuiInstalled = append(guiTuiInstalled, c)
-				}
+		for _, c := range result.Clients {
+			if (c.LauncherType == connect.ClientKindGUI || c.LauncherType == connect.ClientKindTUI) && connect.IsInstalled(c) {
+				guiTuiInstalled = append(guiTuiInstalled, c)
 			}
 		}
 		connectWithAppAvailable = len(guiTuiInstalled) > 0
@@ -66,12 +73,10 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 			return err
 		}
 
-		err = services.ExecuteAccessDetails(cmd, client, session)
-		return err
+		return services.ExecuteCliCommand(cmd, session, details.GetCli())
 
 	case selectors.PrintOption:
-		err = printSessionInstructions(cmd, client, session)
-		return err
+		return printSessionInstructions(cmd, client, session, details)
 
 	case selectors.ExecuteWithAppOption:
 		selectedID, err := selectors.RunLauncherClientSelector(guiTuiInstalled)
@@ -86,7 +91,7 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 		if err != nil {
 			return err
 		}
-		err = connect.NewClientStarter().Start(cmd, client, session.Id, selectedID)
+		err = connect.NewClientStarter().Start(cmd, client, session.Id, selectedID, result)
 		if err != nil {
 			return err
 		}
@@ -98,8 +103,19 @@ func RunUseSessionInteractiveFlow(cmd *cobra.Command, client *aponoapi.AponoClie
 	}
 }
 
-func printSessionInstructions(cmd *cobra.Command, client *aponoapi.AponoClient, session *clientapi.AccessSessionClientModel) error {
-	accessDetails, customInstructionMessage, err := services.GetSessionDetails(cmd.Context(), client, session.Id, services.InstructionsOutputFormat)
+// printSessionInstructions renders and prints a session's instructions. When
+// details is non-nil it reuses that already-fetched result (interactive flow's
+// single consuming fetch); when nil it fetches once itself (the single
+// connection-method path, which has no prior fetch).
+func printSessionInstructions(cmd *cobra.Command, client *aponoapi.AponoClient, session *clientapi.AccessSessionClientModel, details *clientapi.AccessSessionDetailsClientModel) error {
+	var accessDetails string
+	var customInstructionMessage services.CustomInstructionMessage
+	var err error
+	if details != nil {
+		accessDetails, customInstructionMessage, err = services.RenderAccessDetails(details, services.InstructionsOutputFormat)
+	} else {
+		accessDetails, customInstructionMessage, err = services.GetSessionDetails(cmd.Context(), client, session.Id, services.InstructionsOutputFormat)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/services/sessions.go
+++ b/pkg/services/sessions.go
@@ -78,12 +78,8 @@ func ListAccessSessions(ctx context.Context, client *aponoapi.AponoClient, integ
 }
 
 func ExecuteAccessDetails(cobraCmd *cobra.Command, client *aponoapi.AponoClient, session *clientapi.AccessSessionClientModel) error {
-	if runtime.GOOS == "windows" {
-		return errors.New("executing cli commands is not supported on windows")
-	}
-
-	if !utils.Contains(session.ConnectionMethods, CliOutputFormat) {
-		return fmt.Errorf("session %s does not support cli access", session.Id)
+	if err := checkCliExecutable(session); err != nil {
+		return err
 	}
 
 	accessDetails, _, err := client.ClientAPI.AccessSessionsAPI.GetAccessSessionAccessDetails(cobraCmd.Context(), session.Id).
@@ -93,11 +89,27 @@ func ExecuteAccessDetails(cobraCmd *cobra.Command, client *aponoapi.AponoClient,
 		return fmt.Errorf("error getting access details for session id %s: %w", session.Id, err)
 	}
 
-	err = executeCommand(cobraCmd, accessDetails.GetCli())
-	if err != nil {
+	return executeCommand(cobraCmd, accessDetails.GetCli())
+}
+
+// ExecuteCliCommand runs an already-fetched cli command for a session. The
+// interactive flow uses this after its single consuming fetch so it does not
+// fetch (and consume the one-time password) again; the guards match
+// ExecuteAccessDetails.
+func ExecuteCliCommand(cobraCmd *cobra.Command, session *clientapi.AccessSessionClientModel, command string) error {
+	if err := checkCliExecutable(session); err != nil {
 		return err
 	}
+	return executeCommand(cobraCmd, command)
+}
 
+func checkCliExecutable(session *clientapi.AccessSessionClientModel) error {
+	if runtime.GOOS == "windows" {
+		return errors.New("executing cli commands is not supported on windows")
+	}
+	if !utils.Contains(session.ConnectionMethods, CliOutputFormat) {
+		return fmt.Errorf("session %s does not support cli access", session.Id)
+	}
 	return nil
 }
 
@@ -128,6 +140,13 @@ func GetSessionDetails(ctx context.Context, client *aponoapi.AponoClient, sessio
 		return "", "", err
 	}
 
+	return RenderAccessDetails(accessDetails, outputFormat)
+}
+
+// RenderAccessDetails formats already-fetched access details by output format.
+// The interactive flow uses this to render the result of its single consuming
+// fetch instead of fetching (and consuming the one-time password) again.
+func RenderAccessDetails(accessDetails *clientapi.AccessSessionDetailsClientModel, outputFormat string) (string, CustomInstructionMessage, error) {
 	var output string
 	var customInstructionMessage CustomInstructionMessage
 	switch outputFormat {
@@ -142,8 +161,7 @@ func GetSessionDetails(ctx context.Context, client *aponoapi.AponoClient, sessio
 			customInstructionMessage = accessDetails.Instructions.GetCustomMessage()
 		}
 	case JSONOutputFormat:
-		var outputBytes []byte
-		outputBytes, err = json.Marshal(accessDetails.Json)
+		outputBytes, err := json.Marshal(accessDetails.Json)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/services/sessions.go
+++ b/pkg/services/sessions.go
@@ -92,10 +92,6 @@ func ExecuteAccessDetails(cobraCmd *cobra.Command, client *aponoapi.AponoClient,
 	return executeCommand(cobraCmd, accessDetails.GetCli())
 }
 
-// ExecuteCliCommand runs an already-fetched cli command for a session. The
-// interactive flow uses this after its single consuming fetch so it does not
-// fetch (and consume the one-time password) again; the guards match
-// ExecuteAccessDetails.
 func ExecuteCliCommand(cobraCmd *cobra.Command, session *clientapi.AccessSessionClientModel, command string) error {
 	if err := checkCliExecutable(session); err != nil {
 		return err
@@ -143,9 +139,6 @@ func GetSessionDetails(ctx context.Context, client *aponoapi.AponoClient, sessio
 	return RenderAccessDetails(accessDetails, outputFormat)
 }
 
-// RenderAccessDetails formats already-fetched access details by output format.
-// The interactive flow uses this to render the result of its single consuming
-// fetch instead of fetching (and consuming the one-time password) again.
 func RenderAccessDetails(accessDetails *clientapi.AccessSessionDetailsClientModel, outputFormat string) (string, CustomInstructionMessage, error) {
 	var output string
 	var customInstructionMessage CustomInstructionMessage


### PR DESCRIPTION
## Summary

Connecting to a database through the interactive `apono` flow ("Connect to a resource" → pick the DB → **Connect** or **Connect with app**) was failing — pgcli dropped to a `Password:` prompt and GUI apps like DBeaver showed an authentication failure. Worse, once it happened every following connect failed too, until the credentials were reset.

The flow was fetching the session's connection details **twice**. The database password is handed out only once, so the first (throwaway) fetch — used just to decide whether to offer "Connect with app" — burned the password before the actual connect could use it, leaving the real connect with nothing.

The fix fetches once and reuses that single result for the whole flow, so the connect that runs is the one that actually received the password. The non-interactive paths (`--run`, `--client`, `-o`) were never affected and are unchanged.
