### PR TITLE
ci: mint tap publisher token from GitHub App

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,12 +33,24 @@ jobs:
 
       - run: make inst
 
+      # Short-lived installation token for pushing the Homebrew formula and
+      # Scoop manifest. Replaces the long-lived PATs, which expired and broke
+      # the v1.3.21 tap publish.
+      - name: Mint tap publisher token
+        id: tap_token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          client-id: ${{ secrets.TAP_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.TAP_PUBLISHER_PRIVATE_KEY }}
+          owner: apono-io
+          repositories: homebrew-tap,scoop-bucket
+
       - run: goreleaser release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          SCOOP_TAP_GITHUB_TOKEN: ${{ secrets.SCOOP_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}
+          SCOOP_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}
 
       - name: Upload dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

The `v1.3.21` release ([run 30204418649](https://github.com/apono-io/apono-cli/actions/runs/30204418649/job/89799892284)) failed publishing the Homebrew formula:

```
• error checking for default branch  err=GET https://api.github.com/repos/apono-io/homebrew-tap: 401 Bad credentials [] statusCode=401
⨯ release failed after 3m26s  error=homebrew tap formula: failed to publish artifacts: could not get default branch: 401 Bad credentials
```

`401` is an authentication failure, not authorization — a missing scope or lost repo access returns `403`/`404`. The `HOMEBREW_TAP_GITHUB_TOKEN` PAT had expired:

| Event | When |
|---|---|
| `HOMEBREW_TAP_GITHUB_TOKEN` rotated | 2026-06-18 15:36 UTC |
| `SCOOP_TAP_GITHUB_TOKEN` rotated | 2026-06-18 15:36 UTC (same batch) |
| v1.3.20 — taps pushed OK | 2026-06-18 19:22 UTC |
| v1.3.21 — 401 | 2026-07-26 |

Both taps are still at v1.3.20. `SCOOP_TAP_GITHUB_TOKEN` was rotated in the same batch and is presumably also dead — goreleaser aborted on the Homebrew step before reaching the Scoop push.

## What

Replace both long-lived PATs with a short-lived installation token minted per run from an apono-io-owned GitHub App, scoped to `homebrew-tap` and `scoop-bucket` only.

This fixes both failure modes: the App's private key does not expire (fine-grained PATs cap at 366 days, so they would reschedule this outage), and the credential is no longer tied to an individual's personal account. goreleaser still receives a plain token, so **no goreleaser upgrade is needed** — the pinned `v1.17.2` is unchanged.

## Required before merge

This PR fails the release until the App exists and two org secrets are set at [org → Secrets and variables → Actions](https://github.com/organizations/apono-io/settings/secrets/actions):

- `TAP_PUBLISHER_CLIENT_ID` — the App's **Client ID** from its General page (not the App ID)
- `TAP_PUBLISHER_PRIVATE_KEY` — full `.pem` contents including BEGIN/END lines

App configuration: Repository permission **Contents: Read and write** (Metadata read-only is implicit), webhook disabled, installed on `apono-io` with **Only select repositories** → `homebrew-tap`, `scoop-bucket`.

Note `actions/create-github-app-token@v3` deprecates `app-id` in favour of `client-id`, which is why the secret holds the Client ID.

## After merge

- Delete the now-unused `HOMEBREW_TAP_GITHUB_TOKEN` and `SCOOP_TAP_GITHUB_TOKEN` org secrets, and revoke the underlying PAT.
- Re-running `v1.3.21` will still fail with `422 already_exists` on `apono-cli_1.3.21_windows_armv6.zip` — the release already holds its assets and goreleaser v1.17.2 defaults to `mode: keep-existing`. Delete the assets from the [v1.3.21 release](https://github.com/apono-io/apono-cli/releases/tag/v1.3.21) (keeping the release and tag) before re-running. Adding `mode: replace` under `release:` in `.goreleaser.yaml` would prevent this recurring; not included here to keep this PR scoped to the credential fix.

## Testing

YAML validated by parse; `v3.2.0` confirmed to exist upstream. The workflow only triggers on `v*` tag pushes, so this cannot be exercised before the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)