### PR TITLE
DVL-10765 ci: mint tap publisher token from GitHub App

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,12 +33,24 @@ jobs:
 
       - run: make inst
 
+      # Short-lived installation token for pushing the Homebrew formula and
+      # Scoop manifest. Replaces the long-lived PATs, which expired and broke
+      # the v1.3.21 tap publish.
+      - name: Mint tap publisher token
+        id: tap_token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.TAP_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.TAP_PUBLISHER_PRIVATE_KEY }}
+          owner: apono-io
+          repositories: homebrew-tap,scoop-bucket
+
       - run: goreleaser release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
-          SCOOP_TAP_GITHUB_TOKEN: ${{ secrets.SCOOP_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}
+          SCOOP_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}
 
       - name: Upload dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Jira: [DVL-10765](https://apono-io.atlassian.net/browse/DVL-10765)

## Why

The `v1.3.21` release ([run 30204418649](https://github.com/apono-io/apono-cli/actions/runs/30204418649/job/89799892284)) failed publishing the Homebrew formula:

```
• error checking for default branch  err=GET https://api.github.com/repos/apono-io/homebrew-tap: 401 Bad credentials [] statusCode=401
⨯ release failed after 3m26s  error=homebrew tap formula: failed to publish artifacts: could not get default branch: 401 Bad credentials
```

`401` is an authentication failure, not authorization — a missing scope or lost repo access returns `403`/`404`. The `HOMEBREW_TAP_GITHUB_TOKEN` PAT had expired:

| Event | When |
|---|---|
| `HOMEBREW_TAP_GITHUB_TOKEN` rotated | 2026-06-18 15:36 UTC |
| `SCOOP_TAP_GITHUB_TOKEN` rotated | 2026-06-18 15:36 UTC (same batch) |
| v1.3.20 — taps pushed OK | 2026-06-18 19:22 UTC |
| v1.3.21 — 401 | 2026-07-26 |

Both taps are still at v1.3.20, so `brew install apono` and `scoop install apono` serve the stale version. `SCOOP_TAP_GITHUB_TOKEN` came from the same rotation batch and is presumably also dead — goreleaser aborted on the Homebrew step before reaching the Scoop push.

## What

Replace both long-lived PATs with a short-lived installation token minted per run from the org-owned `apono-homebrew-tap-publisher` GitHub App, scoped to `homebrew-tap` and `scoop-bucket` only.

This fixes both failure modes: the App's private key does not expire (fine-grained PATs cap at 366 days and would merely reschedule this outage), and the credential is no longer tied to an individual's personal account. goreleaser still receives a plain token, so **no goreleaser upgrade is needed** — the pinned `v1.17.2` is untouched.

Deploy keys were considered and rejected: goreleaser can push taps over SSH via a `repository.git` block, but that field only landed in goreleaser **v1.19.0** and this repo pins **v1.17.2**, whose `RepoRef` struct has no `git` field. They would also need two separate keys and secrets.

## Prerequisites — already in place

Verified against the org install API:

- App `apono-homebrew-tap-publisher` — App ID `4404646`, installation `149319283`, permissions `contents: write` + `metadata: read`, no webhook events
- Org secrets `TAP_PUBLISHER_APP_ID` and `TAP_PUBLISHER_PRIVATE_KEY` set

**One item still to confirm by hand:** that the installation's repository selection covers *both* `homebrew-tap` and `scoop-bucket`. The App slug is Homebrew-named, so if only `homebrew-tap` was selected the Scoop push will fail on the next release. Check at [installation settings](https://github.com/organizations/apono-io/settings/installations/149319283). I could not verify this via API — listing an installation's repositories requires App or user-token auth.

`actions/create-github-app-token@v3` deprecates `app-id` in favour of `client-id`, but `app-id` remains a functional fallback (`const clientId = getInput("client-id") || getInput("app-id")` in v3.2.0's bundled `main.cjs`), and GitHub accepts the numeric App ID as the JWT issuer. Using `app-id` here to match the secret already created; expect one deprecation annotation per release run. Switching later means renaming the secret to hold the Client ID (`Iv23liGaXIRAmiUZezzb`) and changing the input name.

## After merge

- Delete the now-unused `HOMEBREW_TAP_GITHUB_TOKEN` and `SCOOP_TAP_GITHUB_TOKEN` org secrets, and revoke the underlying PAT.
- Re-running `v1.3.21` will still fail with `422 already_exists` on `apono-cli_1.3.21_windows_armv6.zip` — the release already holds its assets and goreleaser v1.17.2 defaults to `mode: keep-existing`. Delete the assets from the [v1.3.21 release](https://github.com/apono-io/apono-cli/releases/tag/v1.3.21) (keeping release and tag) before re-running. Adding `mode: replace` under `release:` in `.goreleaser.yaml` would stop this recurring; left out to keep this PR scoped to the credential fix.

## Testing

YAML validated by parse; `v3.2.0` confirmed to exist upstream; the `app-id` fallback confirmed by reading the action's bundled source at that tag. The workflow only triggers on `v*` tag pushes, so end-to-end behaviour cannot be exercised until the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DVL-10765]: https://apono-io.atlassian.net/browse/DVL-10765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ