### PR TITLE
fix(ci): Improve CI security pin actions to sha

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,31 +4,30 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
     tags-ignore:
-      - 'v*' # Don't run CI tests on release tags
+      - "v*" # Don't run CI tests on release tags
   pull_request:
 
 jobs:
-
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v3.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
           cache: true
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.APONO_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.APONO_GPG_PASSPHRASE }}
@@ -37,7 +36,7 @@ jobs:
         run: make ci
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: coverage.*
@@ -47,7 +46,7 @@ jobs:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   goreleaser:
@@ -12,21 +12,21 @@ jobs:
       packages: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v3.5.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
           cache: true
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5.2.0
         with:
           gpg_private_key: ${{ secrets.APONO_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.APONO_GPG_PASSPHRASE }}
@@ -38,7 +38,7 @@ jobs:
       # the v1.3.21 tap publish.
       - name: Mint tap publisher token
         id: tap_token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.TAP_PUBLISHER_APP_ID }}
           private-key: ${{ secrets.TAP_PUBLISHER_PRIVATE_KEY }}
@@ -53,7 +53,7 @@ jobs:
           SCOOP_TAP_GITHUB_TOKEN: ${{ steps.tap_token.outputs.token }}
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist


### PR DESCRIPTION
## Overview

Pins all previously unpinned third-party GitHub Actions used in this repo's workflows to immutable commit SHAs instead of mutable version tags, per [GitHub's security hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). The version tag is kept as a trailing comment for readability.

While doing this, GitHub's own first-party actions (`actions/*`) were also updated to their latest major versions, since these are low-risk, actively maintained, and several were multiple majors behind:

- `actions/checkout`: v3.3.0 → v7.0.1
- `actions/setup-go`: v3.5.0 → v7.0.0
- `actions/upload-artifact`: v4 → v7.0.1
- `actions/create-github-app-token`: already on latest (v3.2.0), just pinned

Non-GitHub third-party actions were left on their current version and only pinned to a SHA, not upgraded:

- `crazy-max/ghaction-import-gpg`: pinned at v5.2.0

No functional changes are expected the `actions/*` version bumps were checked against release notes and only involve Node.js runtime upgrades (Node20 → Node24), which GitHub-hosted `ubuntu-22.04` runners handle automatically.

## Type of change
- [x] CI security cleanup

## How to test
No behavior change to verify CI on this PR runs the same steps, now against pinned (and for `actions/*`, updated) versions. Each pin can be confirmed by comparing the tag to the SHA, e.g.:

https://github.com/actions/checkout/tree/v7.0.1

## Changelog
N/A CI/CD infrastructure change only, no user-facing impact.